### PR TITLE
Integrate selected MCP marketplace clients

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,7 @@
+HASHICORP_VAULT_TOKEN=op://vault/hashicorp-vault/token
+OKTA_API_TOKEN=op://vault/okta/api-token
+SSH_PRIVATE_KEY=op://vault/ssh/private-key
+ZENDESK_API_TOKEN=op://vault/zendesk/api-token
+OKTA_ISSUER=op://vault/okta/issuer
+OKTA_CLIENT_ID=op://vault/okta/client-id
+OKTA_REFRESH_TOKEN=op://vault/okta/refresh-token

--- a/README.md
+++ b/README.md
@@ -14,3 +14,4 @@ This repository contains example notes for integrating HashiCorp Vault with 1Pas
 - [Configuration](docs/configuration.md)
 - [Test Cases](docs/testcases.md)
 - [Ansible Playbook](docs/playbook.yml)
+- [Marketplace Clients](mcp_marketplace/README.md)

--- a/mcp_marketplace/README.md
+++ b/mcp_marketplace/README.md
@@ -1,0 +1,13 @@
+# MCP Marketplace Clients
+
+Clients copied from [google/mcp-security](https://github.com/google/mcp-security)
+limited to the following integrations:
+
+- `hashicorpvault`
+- `okta`
+- `ssh`
+- `zendesk`
+
+Use `registry.register_all_tools(mcp)` to expose all tools from these clients.
+Secrets are referenced via environment variables defined in `.env` and stored in
+1Password.

--- a/mcp_marketplace/hashicorpvault.py
+++ b/mcp_marketplace/hashicorpvault.py
@@ -1,0 +1,422 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from secops_soar_mcp import bindings
+from mcp.server.fastmcp import FastMCP
+from secops_soar_mcp.utils.consts import Endpoints
+from secops_soar_mcp.utils.models import ApiManualActionDataModel, EmailContent, TargetEntity
+import json
+from typing import Optional, Any, List, Dict, Union, Annotated
+from pydantic import Field
+
+
+def register_tools(mcp: FastMCP):
+    # This function registers all tools (actions) for the HashiCorpVault integration.
+
+    @mcp.tool()
+    async def hashi_corp_vault_generate_aws_credentials(case_id: Annotated[str, Field(..., description="The ID of the case.")], alert_group_identifiers: Annotated[List[str], Field(..., description="Identifiers for the alert groups.")], aws_role_name: Annotated[str, Field(..., description="Specify the role name to generate credentials for.")], aws_secret_engine_path: Annotated[str, Field(default=None, description="Specify the path used for the aws secret storage. Parameter is used to interact with secrets stored in storage, it is used to construct the urls like https://x.x.x.x:8200/v1/aws/roles/")], aws_role_arn: Annotated[str, Field(default=None, description="Specify the ARN of the role to assume if credential_type on the Vault role is assumed_role. Must match one of the allowed role ARNs in the Vault role.")], aws_role_session_name: Annotated[str, Field(default=None, description="Specify the role session name to attach to the assumed role ARN. If not provided it will be generated dynamically by default.")], ttl_seconds: Annotated[str, Field(default=None, description="Specifies the TTL in seconds for the use of the STS token. This is specified as a string with a duration suffix. Valid only when AWS role credential_type in Vault is assumed_role or federation_token. When not specified, the default_sts_ttl set for the role will be used. If that is also not set, then the default value of 3600 seconds will be used.")], json_expression_builder: Annotated[Union[str, dict], Field(default=None, description="Specify a JSON Expression Builder expression to filter a specific subset of data from secret, for example:  | \u201cdata\u201d | \u201cdata\u201d | \u201ckey0\u201d")], target_entities: Annotated[List[TargetEntity], Field(default_factory=list, description="Optional list of specific target entities (Identifier, EntityType) to run the action on.")], scope: Annotated[str, Field(default="All entities", description="Defines the scope for the action.")]) -> dict:
+        """Generate credentials based on AWS role stored in HashiCorp Vault. Note: This action doesn’t run on Chronicle SOAR entities.
+
+        Returns:
+            dict: A dictionary containing the result of the action execution.
+        """
+        final_target_entities: Optional[List[TargetEntity]] = None
+        final_scope: Optional[str] = None
+        is_predefined_scope: Optional[bool] = None
+    
+        if target_entities:
+            # Specific target entities provided, ignore scope parameter
+            final_target_entities = target_entities
+            final_scope = None
+            is_predefined_scope = False
+        else:
+            # Check if the provided scope is valid
+            if scope not in bindings.valid_scopes:
+                allowed_values_str = ", ".join(sorted(list(bindings.valid_scopes)))
+                return {
+                    "Status": "Failed",
+                    "Message": f"Invalid scope '{scope}'. Allowed values are: {allowed_values_str}",
+                }
+            final_target_entities = [] # Pass empty list for entities when using scope
+            final_scope = scope
+            is_predefined_scope = True
+    
+        # Fetch integration instance identifier
+        try:
+            instance_response = await bindings.http_client.get(
+                Endpoints.LIST_INTEGRATION_INSTANCES.format(INTEGRATION_NAME="HashiCorpVault")
+            )
+            instances = instance_response.get("integration_instances", [])
+        except Exception as e:
+            print(f"Error fetching instance for HashiCorpVault: {e}")
+            return {"Status": "Failed", "Message": f"Error fetching instance: {e}"}
+    
+        if instances:
+            instance_identifier = instances[0].get("identifier")
+            if not instance_identifier:
+                return {"Status": "Failed", "Message": "Instance found but identifier is missing."}
+    
+            script_params = {}
+            if aws_secret_engine_path is not None:
+                script_params["AWS Secret Engine Path"] = aws_secret_engine_path
+            script_params["AWS Role Name"] = aws_role_name
+            if aws_role_arn is not None:
+                script_params["AWS Role ARN"] = aws_role_arn
+            if aws_role_session_name is not None:
+                script_params["AWS Role Session Name"] = aws_role_session_name
+            if ttl_seconds is not None:
+                script_params["TTL (seconds)"] = ttl_seconds
+            if json_expression_builder is not None:
+                script_params["JSON Expression Builder"] = json_expression_builder
+    
+            # Prepare data model for the API request
+            action_data = ApiManualActionDataModel(
+                alertGroupIdentifiers=alert_group_identifiers,
+                caseId=case_id,
+                targetEntities=final_target_entities,
+                scope=final_scope,
+                isPredefinedScope=is_predefined_scope,
+                actionProvider="Scripts",
+                actionName="HashiCorpVault_Generate AWS Credentials",
+                properties={
+                    "IntegrationInstance": instance_identifier,
+                    "ScriptName": "HashiCorpVault_Generate AWS Credentials",
+                    "ScriptParametersEntityFields": json.dumps(script_params)
+                }
+            )
+    
+            try:
+                execution_response = await bindings.http_client.post(
+                    Endpoints.EXECUTE_MANUAL_ACTION,
+                    req=action_data.model_dump()
+                )
+                return execution_response
+            except Exception as e:
+                print(f"Error executing action HashiCorpVault_Generate AWS Credentials for HashiCorpVault: {e}")
+                return {"Status": "Failed", "Message": f"Error executing action: {e}"}
+        else:
+            print(f"Warning: No active integration instance found for HashiCorpVault")
+            return {"Status": "Failed", "Message": "No active instance found."}
+
+    @mcp.tool()
+    async def hashi_corp_vault_ping(case_id: Annotated[str, Field(..., description="The ID of the case.")], alert_group_identifiers: Annotated[List[str], Field(..., description="Identifiers for the alert groups.")], target_entities: Annotated[List[TargetEntity], Field(default_factory=list, description="Optional list of specific target entities (Identifier, EntityType) to run the action on.")], scope: Annotated[str, Field(default="All entities", description="Defines the scope for the action.")]) -> dict:
+        """Test connectivity to the HashiCorp Vault installation with parameters provided at the integration configuration page on the Marketplace tab.
+
+        Returns:
+            dict: A dictionary containing the result of the action execution.
+        """
+        final_target_entities: Optional[List[TargetEntity]] = None
+        final_scope: Optional[str] = None
+        is_predefined_scope: Optional[bool] = None
+    
+        if target_entities:
+            # Specific target entities provided, ignore scope parameter
+            final_target_entities = target_entities
+            final_scope = None
+            is_predefined_scope = False
+        else:
+            # Check if the provided scope is valid
+            if scope not in bindings.valid_scopes:
+                allowed_values_str = ", ".join(sorted(list(bindings.valid_scopes)))
+                return {
+                    "Status": "Failed",
+                    "Message": f"Invalid scope '{scope}'. Allowed values are: {allowed_values_str}",
+                }
+            final_target_entities = [] # Pass empty list for entities when using scope
+            final_scope = scope
+            is_predefined_scope = True
+    
+        # Fetch integration instance identifier
+        try:
+            instance_response = await bindings.http_client.get(
+                Endpoints.LIST_INTEGRATION_INSTANCES.format(INTEGRATION_NAME="HashiCorpVault")
+            )
+            instances = instance_response.get("integration_instances", [])
+        except Exception as e:
+            print(f"Error fetching instance for HashiCorpVault: {e}")
+            return {"Status": "Failed", "Message": f"Error fetching instance: {e}"}
+    
+        if instances:
+            instance_identifier = instances[0].get("identifier")
+            if not instance_identifier:
+                return {"Status": "Failed", "Message": "Instance found but identifier is missing."}
+    
+            script_params = {}
+    
+            # Prepare data model for the API request
+            action_data = ApiManualActionDataModel(
+                alertGroupIdentifiers=alert_group_identifiers,
+                caseId=case_id,
+                targetEntities=final_target_entities,
+                scope=final_scope,
+                isPredefinedScope=is_predefined_scope,
+                actionProvider="Scripts",
+                actionName="HashiCorpVault_Ping",
+                properties={
+                    "IntegrationInstance": instance_identifier,
+                    "ScriptName": "HashiCorpVault_Ping",
+                    "ScriptParametersEntityFields": json.dumps(script_params)
+                }
+            )
+    
+            try:
+                execution_response = await bindings.http_client.post(
+                    Endpoints.EXECUTE_MANUAL_ACTION,
+                    req=action_data.model_dump()
+                )
+                return execution_response
+            except Exception as e:
+                print(f"Error executing action HashiCorpVault_Ping for HashiCorpVault: {e}")
+                return {"Status": "Failed", "Message": f"Error executing action: {e}"}
+        else:
+            print(f"Warning: No active integration instance found for HashiCorpVault")
+            return {"Status": "Failed", "Message": "No active instance found."}
+
+    @mcp.tool()
+    async def hashi_corp_vault_list_key_value_secret_keys(case_id: Annotated[str, Field(..., description="The ID of the case.")], alert_group_identifiers: Annotated[List[str], Field(..., description="Identifiers for the alert groups.")], key_value_secret_engine_path: Annotated[str, Field(default=None, description="Specify the path used for the key-value secret storage. Currently only version 2 is supported. Parameter is used to interact with secrets stored in storage, it is used to construct the urls like https://x.x.x.x:8200/v1/secret/data/<secret to fetch from kv store>")], secret_path: Annotated[str, Field(default=None, description="Specify secret path to fetch, action accept folder names, example secret path folder name is my-secret, key-value store path is secret, so full path to fetch would be \"https://x.x.x.x:8200/v1/secret/data/my-secret\". If not provided, action will return all secret keys stored in the secret engine.")], max_records_to_return: Annotated[str, Field(default=None, description="Specify how many records to return. If nothing is provided, action will return 50 records.")], target_entities: Annotated[List[TargetEntity], Field(default_factory=list, description="Optional list of specific target entities (Identifier, EntityType) to run the action on.")], scope: Annotated[str, Field(default="All entities", description="Defines the scope for the action.")]) -> dict:
+        """List secrets keys available in the HashiCorp Vault based on provided criteria. Action returns key names stored in secret path without values. Folder names should be specified for secret path, action does not work if secret key is provided. Note: This action doesn't run on Chronicle SOAR entities.
+
+        Returns:
+            dict: A dictionary containing the result of the action execution.
+        """
+        final_target_entities: Optional[List[TargetEntity]] = None
+        final_scope: Optional[str] = None
+        is_predefined_scope: Optional[bool] = None
+    
+        if target_entities:
+            # Specific target entities provided, ignore scope parameter
+            final_target_entities = target_entities
+            final_scope = None
+            is_predefined_scope = False
+        else:
+            # Check if the provided scope is valid
+            if scope not in bindings.valid_scopes:
+                allowed_values_str = ", ".join(sorted(list(bindings.valid_scopes)))
+                return {
+                    "Status": "Failed",
+                    "Message": f"Invalid scope '{scope}'. Allowed values are: {allowed_values_str}",
+                }
+            final_target_entities = [] # Pass empty list for entities when using scope
+            final_scope = scope
+            is_predefined_scope = True
+    
+        # Fetch integration instance identifier
+        try:
+            instance_response = await bindings.http_client.get(
+                Endpoints.LIST_INTEGRATION_INSTANCES.format(INTEGRATION_NAME="HashiCorpVault")
+            )
+            instances = instance_response.get("integration_instances", [])
+        except Exception as e:
+            print(f"Error fetching instance for HashiCorpVault: {e}")
+            return {"Status": "Failed", "Message": f"Error fetching instance: {e}"}
+    
+        if instances:
+            instance_identifier = instances[0].get("identifier")
+            if not instance_identifier:
+                return {"Status": "Failed", "Message": "Instance found but identifier is missing."}
+    
+            script_params = {}
+            if key_value_secret_engine_path is not None:
+                script_params["Key-Value Secret Engine Path"] = key_value_secret_engine_path
+            if secret_path is not None:
+                script_params["Secret Path"] = secret_path
+            if max_records_to_return is not None:
+                script_params["Max Records To Return"] = max_records_to_return
+    
+            # Prepare data model for the API request
+            action_data = ApiManualActionDataModel(
+                alertGroupIdentifiers=alert_group_identifiers,
+                caseId=case_id,
+                targetEntities=final_target_entities,
+                scope=final_scope,
+                isPredefinedScope=is_predefined_scope,
+                actionProvider="Scripts",
+                actionName="HashiCorpVault_List Key-Value Secret Keys",
+                properties={
+                    "IntegrationInstance": instance_identifier,
+                    "ScriptName": "HashiCorpVault_List Key-Value Secret Keys",
+                    "ScriptParametersEntityFields": json.dumps(script_params)
+                }
+            )
+    
+            try:
+                execution_response = await bindings.http_client.post(
+                    Endpoints.EXECUTE_MANUAL_ACTION,
+                    req=action_data.model_dump()
+                )
+                return execution_response
+            except Exception as e:
+                print(f"Error executing action HashiCorpVault_List Key-Value Secret Keys for HashiCorpVault: {e}")
+                return {"Status": "Failed", "Message": f"Error executing action: {e}"}
+        else:
+            print(f"Warning: No active integration instance found for HashiCorpVault")
+            return {"Status": "Failed", "Message": "No active instance found."}
+
+    @mcp.tool()
+    async def hashi_corp_vault_list_aws_roles(case_id: Annotated[str, Field(..., description="The ID of the case.")], alert_group_identifiers: Annotated[List[str], Field(..., description="Identifiers for the alert groups.")], aws_secret_engine_path: Annotated[str, Field(default=None, description="Specify the path used for the aws secret storage. Parameter is used to interact with secrets stored in storage, it is used to construct the urls like https://x.x.x.x:8200/v1/aws/roles/")], max_records_to_return: Annotated[str, Field(default=None, description="Specify how many records to return. If nothing is provided, action will return 50 records.")], target_entities: Annotated[List[TargetEntity], Field(default_factory=list, description="Optional list of specific target entities (Identifier, EntityType) to run the action on.")], scope: Annotated[str, Field(default="All entities", description="Defines the scope for the action.")]) -> dict:
+        """List AWS roles available in the HashiCorp Vault based on provided criteria. Note: This action doesn’t run on Chronicle SOAR entities.
+
+        Returns:
+            dict: A dictionary containing the result of the action execution.
+        """
+        final_target_entities: Optional[List[TargetEntity]] = None
+        final_scope: Optional[str] = None
+        is_predefined_scope: Optional[bool] = None
+    
+        if target_entities:
+            # Specific target entities provided, ignore scope parameter
+            final_target_entities = target_entities
+            final_scope = None
+            is_predefined_scope = False
+        else:
+            # Check if the provided scope is valid
+            if scope not in bindings.valid_scopes:
+                allowed_values_str = ", ".join(sorted(list(bindings.valid_scopes)))
+                return {
+                    "Status": "Failed",
+                    "Message": f"Invalid scope '{scope}'. Allowed values are: {allowed_values_str}",
+                }
+            final_target_entities = [] # Pass empty list for entities when using scope
+            final_scope = scope
+            is_predefined_scope = True
+    
+        # Fetch integration instance identifier
+        try:
+            instance_response = await bindings.http_client.get(
+                Endpoints.LIST_INTEGRATION_INSTANCES.format(INTEGRATION_NAME="HashiCorpVault")
+            )
+            instances = instance_response.get("integration_instances", [])
+        except Exception as e:
+            print(f"Error fetching instance for HashiCorpVault: {e}")
+            return {"Status": "Failed", "Message": f"Error fetching instance: {e}"}
+    
+        if instances:
+            instance_identifier = instances[0].get("identifier")
+            if not instance_identifier:
+                return {"Status": "Failed", "Message": "Instance found but identifier is missing."}
+    
+            script_params = {}
+            if aws_secret_engine_path is not None:
+                script_params["AWS Secret Engine Path"] = aws_secret_engine_path
+            if max_records_to_return is not None:
+                script_params["Max Records To Return"] = max_records_to_return
+    
+            # Prepare data model for the API request
+            action_data = ApiManualActionDataModel(
+                alertGroupIdentifiers=alert_group_identifiers,
+                caseId=case_id,
+                targetEntities=final_target_entities,
+                scope=final_scope,
+                isPredefinedScope=is_predefined_scope,
+                actionProvider="Scripts",
+                actionName="HashiCorpVault_List AWS Roles",
+                properties={
+                    "IntegrationInstance": instance_identifier,
+                    "ScriptName": "HashiCorpVault_List AWS Roles",
+                    "ScriptParametersEntityFields": json.dumps(script_params)
+                }
+            )
+    
+            try:
+                execution_response = await bindings.http_client.post(
+                    Endpoints.EXECUTE_MANUAL_ACTION,
+                    req=action_data.model_dump()
+                )
+                return execution_response
+            except Exception as e:
+                print(f"Error executing action HashiCorpVault_List AWS Roles for HashiCorpVault: {e}")
+                return {"Status": "Failed", "Message": f"Error executing action: {e}"}
+        else:
+            print(f"Warning: No active integration instance found for HashiCorpVault")
+            return {"Status": "Failed", "Message": "No active instance found."}
+
+    @mcp.tool()
+    async def hashi_corp_vault_read_key_value_secret(case_id: Annotated[str, Field(..., description="The ID of the case.")], alert_group_identifiers: Annotated[List[str], Field(..., description="Identifiers for the alert groups.")], secret_path: Annotated[str, Field(..., description="Specify secret path to fetch, example secret path is my-secret, key-value store path is secret, so full path to fetch would be \"https://x.x.x.x:8200/v1/secret/data/my-secret\".")], key_value_secret_engine_path: Annotated[str, Field(default=None, description="Specify the path used for the key-value secret storage. Currently only version 2 is supported. Parameter is used to interact with secrets stored in storage, it is used to construct the urls like https://x.x.x.x:8200/v1/secret/data/<secret to fetch from kv store>")], secret_version: Annotated[str, Field(default=None, description="Specify a secret version to fetch.")], json_expression_builder: Annotated[Union[str, dict], Field(default=None, description="Specify a JSON Expression Builder expression to filter a specific subset of data from secret, for example: data | data | key0")], target_entities: Annotated[List[TargetEntity], Field(default_factory=list, description="Optional list of specific target entities (Identifier, EntityType) to run the action on.")], scope: Annotated[str, Field(default="All entities", description="Defines the scope for the action.")]) -> dict:
+        """Read Key-Value secret stored in HashiCorp Vault based on provided criteria. Note: This action doesn't run on Chronicle SOAR entities.
+
+        Returns:
+            dict: A dictionary containing the result of the action execution.
+        """
+        final_target_entities: Optional[List[TargetEntity]] = None
+        final_scope: Optional[str] = None
+        is_predefined_scope: Optional[bool] = None
+    
+        if target_entities:
+            # Specific target entities provided, ignore scope parameter
+            final_target_entities = target_entities
+            final_scope = None
+            is_predefined_scope = False
+        else:
+            # Check if the provided scope is valid
+            if scope not in bindings.valid_scopes:
+                allowed_values_str = ", ".join(sorted(list(bindings.valid_scopes)))
+                return {
+                    "Status": "Failed",
+                    "Message": f"Invalid scope '{scope}'. Allowed values are: {allowed_values_str}",
+                }
+            final_target_entities = [] # Pass empty list for entities when using scope
+            final_scope = scope
+            is_predefined_scope = True
+    
+        # Fetch integration instance identifier
+        try:
+            instance_response = await bindings.http_client.get(
+                Endpoints.LIST_INTEGRATION_INSTANCES.format(INTEGRATION_NAME="HashiCorpVault")
+            )
+            instances = instance_response.get("integration_instances", [])
+        except Exception as e:
+            print(f"Error fetching instance for HashiCorpVault: {e}")
+            return {"Status": "Failed", "Message": f"Error fetching instance: {e}"}
+    
+        if instances:
+            instance_identifier = instances[0].get("identifier")
+            if not instance_identifier:
+                return {"Status": "Failed", "Message": "Instance found but identifier is missing."}
+    
+            script_params = {}
+            if key_value_secret_engine_path is not None:
+                script_params["Key-Value Secret Engine Path"] = key_value_secret_engine_path
+            script_params["Secret Path"] = secret_path
+            if secret_version is not None:
+                script_params["Secret Version"] = secret_version
+            if json_expression_builder is not None:
+                script_params["JSON Expression Builder"] = json_expression_builder
+    
+            # Prepare data model for the API request
+            action_data = ApiManualActionDataModel(
+                alertGroupIdentifiers=alert_group_identifiers,
+                caseId=case_id,
+                targetEntities=final_target_entities,
+                scope=final_scope,
+                isPredefinedScope=is_predefined_scope,
+                actionProvider="Scripts",
+                actionName="HashiCorpVault_Read Key-Value Secret",
+                properties={
+                    "IntegrationInstance": instance_identifier,
+                    "ScriptName": "HashiCorpVault_Read Key-Value Secret",
+                    "ScriptParametersEntityFields": json.dumps(script_params)
+                }
+            )
+    
+            try:
+                execution_response = await bindings.http_client.post(
+                    Endpoints.EXECUTE_MANUAL_ACTION,
+                    req=action_data.model_dump()
+                )
+                return execution_response
+            except Exception as e:
+                print(f"Error executing action HashiCorpVault_Read Key-Value Secret for HashiCorpVault: {e}")
+                return {"Status": "Failed", "Message": f"Error executing action: {e}"}
+        else:
+            print(f"Warning: No active integration instance found for HashiCorpVault")
+            return {"Status": "Failed", "Message": "No active instance found."}

--- a/mcp_marketplace/okta.py
+++ b/mcp_marketplace/okta.py
@@ -1,0 +1,1163 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from secops_soar_mcp import bindings
+from mcp.server.fastmcp import FastMCP
+from secops_soar_mcp.utils.consts import Endpoints
+from secops_soar_mcp.utils.models import ApiManualActionDataModel, EmailContent, TargetEntity
+import json
+from typing import Optional, Any, List, Dict, Union, Annotated
+from pydantic import Field
+
+
+def register_tools(mcp: FastMCP):
+    # This function registers all tools (actions) for the Okta integration.
+
+    @mcp.tool()
+    async def okta_list_providers(case_id: Annotated[str, Field(..., description="The ID of the case.")], alert_group_identifiers: Annotated[List[str], Field(..., description="Identifiers for the alert groups.")], query: Annotated[str, Field(default=None, description="Search the name property for a match")], type: Annotated[str, Field(default=None, description="Filter by type")], limit: Annotated[str, Field(default=None, description="Max amount of results to return")], target_entities: Annotated[List[TargetEntity], Field(default_factory=list, description="Optional list of specific target entities (Identifier, EntityType) to run the action on.")], scope: Annotated[str, Field(default="All entities", description="Defines the scope for the action.")]) -> dict:
+        """
+List identity providers (IdPs) in your organization
+
+Action Parameters: Query: Search the name property for a match., Type: Filter by type., Limit: Max amount of results to return.
+
+Returns:
+dict: A dictionary containing the result of the action execution.
+"""
+        final_target_entities: Optional[List[TargetEntity]] = None
+        final_scope: Optional[str] = None
+        is_predefined_scope: Optional[bool] = None
+    
+        if target_entities:
+            # Specific target entities provided, ignore scope parameter
+            final_target_entities = target_entities
+            final_scope = None
+            is_predefined_scope = False
+        else:
+            # Check if the provided scope is valid
+            if scope not in bindings.valid_scopes:
+                allowed_values_str = ", ".join(sorted(list(bindings.valid_scopes)))
+                return {
+                    "Status": "Failed",
+                    "Message": f"Invalid scope '{scope}'. Allowed values are: {allowed_values_str}",
+                }
+            final_target_entities = [] # Pass empty list for entities when using scope
+            final_scope = scope
+            is_predefined_scope = True
+    
+        # Fetch integration instance identifier
+        try:
+            instance_response = await bindings.http_client.get(
+                Endpoints.LIST_INTEGRATION_INSTANCES.format(INTEGRATION_NAME="Okta")
+            )
+            instances = instance_response.get("integration_instances", [])
+        except Exception as e:
+            print(f"Error fetching instance for Okta: {e}")
+            return {"Status": "Failed", "Message": f"Error fetching instance: {e}"}
+    
+        if instances:
+            instance_identifier = instances[0].get("identifier")
+            if not instance_identifier:
+                return {"Status": "Failed", "Message": "Instance found but identifier is missing."}
+    
+            script_params = {}
+            if query is not None:
+                script_params["Query"] = query
+            if type is not None:
+                script_params["Type"] = type
+            if limit is not None:
+                script_params["Limit"] = limit
+    
+            # Prepare data model for the API request
+            action_data = ApiManualActionDataModel(
+                alertGroupIdentifiers=alert_group_identifiers,
+                caseId=case_id,
+                targetEntities=final_target_entities,
+                scope=final_scope,
+                isPredefinedScope=is_predefined_scope,
+                actionProvider="Scripts",
+                actionName="Okta_List Providers",
+                properties={
+                    "IntegrationInstance": instance_identifier,
+                    "ScriptName": "Okta_List Providers",
+                    "ScriptParametersEntityFields": json.dumps(script_params)
+                }
+            )
+    
+            try:
+                execution_response = await bindings.http_client.post(
+                    Endpoints.EXECUTE_MANUAL_ACTION,
+                    req=action_data.model_dump()
+                )
+                return execution_response
+            except Exception as e:
+                print(f"Error executing action Okta_List Providers for Okta: {e}")
+                return {"Status": "Failed", "Message": f"Error executing action: {e}"}
+        else:
+            print(f"Warning: No active integration instance found for Okta")
+            return {"Status": "Failed", "Message": "No active instance found."}
+
+    @mcp.tool()
+    async def okta_assign_role(case_id: Annotated[str, Field(..., description="The ID of the case.")], alert_group_identifiers: Annotated[List[str], Field(..., description="Identifiers for the alert groups.")], role_types: Annotated[str, Field(..., description="The type of role to assign to the users")], user_i_ds: Annotated[str, Field(default=None, description="Ids of users in Okta")], also_run_on_scope: Annotated[bool, Field(default=None, description="Whether to run on entities as well as the input")], target_entities: Annotated[List[TargetEntity], Field(default_factory=list, description="Optional list of specific target entities (Identifier, EntityType) to run the action on.")], scope: Annotated[str, Field(default="All entities", description="Defines the scope for the action.")]) -> dict:
+        """
+Assign a role to a user
+
+Action Parameters: User IDs: IDs of users in Okta., Role Types: The type of role to assign to the users., Also Run On Scope: Whether to run on entities as well as the input.
+
+Returns:
+dict: A dictionary containing the result of the action execution.
+"""
+        final_target_entities: Optional[List[TargetEntity]] = None
+        final_scope: Optional[str] = None
+        is_predefined_scope: Optional[bool] = None
+    
+        if target_entities:
+            # Specific target entities provided, ignore scope parameter
+            final_target_entities = target_entities
+            final_scope = None
+            is_predefined_scope = False
+        else:
+            # Check if the provided scope is valid
+            if scope not in bindings.valid_scopes:
+                allowed_values_str = ", ".join(sorted(list(bindings.valid_scopes)))
+                return {
+                    "Status": "Failed",
+                    "Message": f"Invalid scope '{scope}'. Allowed values are: {allowed_values_str}",
+                }
+            final_target_entities = [] # Pass empty list for entities when using scope
+            final_scope = scope
+            is_predefined_scope = True
+    
+        # Fetch integration instance identifier
+        try:
+            instance_response = await bindings.http_client.get(
+                Endpoints.LIST_INTEGRATION_INSTANCES.format(INTEGRATION_NAME="Okta")
+            )
+            instances = instance_response.get("integration_instances", [])
+        except Exception as e:
+            print(f"Error fetching instance for Okta: {e}")
+            return {"Status": "Failed", "Message": f"Error fetching instance: {e}"}
+    
+        if instances:
+            instance_identifier = instances[0].get("identifier")
+            if not instance_identifier:
+                return {"Status": "Failed", "Message": "Instance found but identifier is missing."}
+    
+            script_params = {}
+            if user_i_ds is not None:
+                script_params["User IDs"] = user_i_ds
+            script_params["Role Types"] = role_types
+            if also_run_on_scope is not None:
+                script_params["Also Run On Scope"] = also_run_on_scope
+    
+            # Prepare data model for the API request
+            action_data = ApiManualActionDataModel(
+                alertGroupIdentifiers=alert_group_identifiers,
+                caseId=case_id,
+                targetEntities=final_target_entities,
+                scope=final_scope,
+                isPredefinedScope=is_predefined_scope,
+                actionProvider="Scripts",
+                actionName="Okta_Assign Role",
+                properties={
+                    "IntegrationInstance": instance_identifier,
+                    "ScriptName": "Okta_Assign Role",
+                    "ScriptParametersEntityFields": json.dumps(script_params)
+                }
+            )
+    
+            try:
+                execution_response = await bindings.http_client.post(
+                    Endpoints.EXECUTE_MANUAL_ACTION,
+                    req=action_data.model_dump()
+                )
+                return execution_response
+            except Exception as e:
+                print(f"Error executing action Okta_Assign Role for Okta: {e}")
+                return {"Status": "Failed", "Message": f"Error executing action: {e}"}
+        else:
+            print(f"Warning: No active integration instance found for Okta")
+            return {"Status": "Failed", "Message": "No active instance found."}
+
+    @mcp.tool()
+    async def okta_unassign_role(case_id: Annotated[str, Field(..., description="The ID of the case.")], alert_group_identifiers: Annotated[List[str], Field(..., description="Identifiers for the alert groups.")], role_i_ds_or_names: Annotated[str, Field(..., description="Ids or names of roles in Okta")], user_i_ds: Annotated[str, Field(default=None, description="Ids of users in Okta")], is_id: Annotated[bool, Field(default=None, description="Whether the values are ids or names")], also_run_on_scope: Annotated[bool, Field(default=None, description="Whether to run on entities as well as the input")], target_entities: Annotated[List[TargetEntity], Field(default_factory=list, description="Optional list of specific target entities (Identifier, EntityType) to run the action on.")], scope: Annotated[str, Field(default="All entities", description="Defines the scope for the action.")]) -> dict:
+        """Unassign a role from a user
+
+        Returns:
+            dict: A dictionary containing the result of the action execution.
+        """
+        final_target_entities: Optional[List[TargetEntity]] = None
+        final_scope: Optional[str] = None
+        is_predefined_scope: Optional[bool] = None
+    
+        if target_entities:
+            # Specific target entities provided, ignore scope parameter
+            final_target_entities = target_entities
+            final_scope = None
+            is_predefined_scope = False
+        else:
+            # Check if the provided scope is valid
+            if scope not in bindings.valid_scopes:
+                allowed_values_str = ", ".join(sorted(list(bindings.valid_scopes)))
+                return {
+                    "Status": "Failed",
+                    "Message": f"Invalid scope '{scope}'. Allowed values are: {allowed_values_str}",
+                }
+            final_target_entities = [] # Pass empty list for entities when using scope
+            final_scope = scope
+            is_predefined_scope = True
+    
+        # Fetch integration instance identifier
+        try:
+            instance_response = await bindings.http_client.get(
+                Endpoints.LIST_INTEGRATION_INSTANCES.format(INTEGRATION_NAME="Okta")
+            )
+            instances = instance_response.get("integration_instances", [])
+        except Exception as e:
+            print(f"Error fetching instance for Okta: {e}")
+            return {"Status": "Failed", "Message": f"Error fetching instance: {e}"}
+    
+        if instances:
+            instance_identifier = instances[0].get("identifier")
+            if not instance_identifier:
+                return {"Status": "Failed", "Message": "Instance found but identifier is missing."}
+    
+            script_params = {}
+            if user_i_ds is not None:
+                script_params["User IDs"] = user_i_ds
+            script_params["Role IDs Or Names"] = role_i_ds_or_names
+            if is_id is not None:
+                script_params["Is Id"] = is_id
+            if also_run_on_scope is not None:
+                script_params["Also Run On Scope"] = also_run_on_scope
+    
+            # Prepare data model for the API request
+            action_data = ApiManualActionDataModel(
+                alertGroupIdentifiers=alert_group_identifiers,
+                caseId=case_id,
+                targetEntities=final_target_entities,
+                scope=final_scope,
+                isPredefinedScope=is_predefined_scope,
+                actionProvider="Scripts",
+                actionName="Okta_Unassign Role",
+                properties={
+                    "IntegrationInstance": instance_identifier,
+                    "ScriptName": "Okta_Unassign Role",
+                    "ScriptParametersEntityFields": json.dumps(script_params)
+                }
+            )
+    
+            try:
+                execution_response = await bindings.http_client.post(
+                    Endpoints.EXECUTE_MANUAL_ACTION,
+                    req=action_data.model_dump()
+                )
+                return execution_response
+            except Exception as e:
+                print(f"Error executing action Okta_Unassign Role for Okta: {e}")
+                return {"Status": "Failed", "Message": f"Error executing action: {e}"}
+        else:
+            print(f"Warning: No active integration instance found for Okta")
+            return {"Status": "Failed", "Message": "No active instance found."}
+
+    @mcp.tool()
+    async def okta_disable_user(case_id: Annotated[str, Field(..., description="The ID of the case.")], alert_group_identifiers: Annotated[List[str], Field(..., description="Identifiers for the alert groups.")], user_i_ds_or_logins: Annotated[str, Field(default=None, description="Ids of users in Okta")], is_deactivate: Annotated[bool, Field(default=None, description="Whether to dactivate or only suspend the user")], send_email_if_deactivate: Annotated[bool, Field(default=None, description="Whether to send an email after deactivating or not")], also_run_on_scope: Annotated[bool, Field(default=None, description="Whether to run on entities as well as the input")], target_entities: Annotated[List[TargetEntity], Field(default_factory=list, description="Optional list of specific target entities (Identifier, EntityType) to run the action on.")], scope: Annotated[str, Field(default="All entities", description="Defines the scope for the action.")]) -> dict:
+        """
+Disables the specified user
+
+Action Parameters: User IDs Or Logins: IDs of users in Okta., Is Deactivate: Whether to deactivate or only suspend the user., Send Email If Deactivate: Whether to send an email after deactivating or not., Also Run On Scope: Whether to run on entities as well as the input.
+
+Returns:
+dict: A dictionary containing the result of the action execution.
+"""
+        final_target_entities: Optional[List[TargetEntity]] = None
+        final_scope: Optional[str] = None
+        is_predefined_scope: Optional[bool] = None
+    
+        if target_entities:
+            # Specific target entities provided, ignore scope parameter
+            final_target_entities = target_entities
+            final_scope = None
+            is_predefined_scope = False
+        else:
+            # Check if the provided scope is valid
+            if scope not in bindings.valid_scopes:
+                allowed_values_str = ", ".join(sorted(list(bindings.valid_scopes)))
+                return {
+                    "Status": "Failed",
+                    "Message": f"Invalid scope '{scope}'. Allowed values are: {allowed_values_str}",
+                }
+            final_target_entities = [] # Pass empty list for entities when using scope
+            final_scope = scope
+            is_predefined_scope = True
+    
+        # Fetch integration instance identifier
+        try:
+            instance_response = await bindings.http_client.get(
+                Endpoints.LIST_INTEGRATION_INSTANCES.format(INTEGRATION_NAME="Okta")
+            )
+            instances = instance_response.get("integration_instances", [])
+        except Exception as e:
+            print(f"Error fetching instance for Okta: {e}")
+            return {"Status": "Failed", "Message": f"Error fetching instance: {e}"}
+    
+        if instances:
+            instance_identifier = instances[0].get("identifier")
+            if not instance_identifier:
+                return {"Status": "Failed", "Message": "Instance found but identifier is missing."}
+    
+            script_params = {}
+            if user_i_ds_or_logins is not None:
+                script_params["User IDs Or Logins"] = user_i_ds_or_logins
+            if is_deactivate is not None:
+                script_params["Is Deactivate"] = is_deactivate
+            if send_email_if_deactivate is not None:
+                script_params["Send Email If Deactivate"] = send_email_if_deactivate
+            if also_run_on_scope is not None:
+                script_params["Also Run On Scope"] = also_run_on_scope
+    
+            # Prepare data model for the API request
+            action_data = ApiManualActionDataModel(
+                alertGroupIdentifiers=alert_group_identifiers,
+                caseId=case_id,
+                targetEntities=final_target_entities,
+                scope=final_scope,
+                isPredefinedScope=is_predefined_scope,
+                actionProvider="Scripts",
+                actionName="Okta_Disable User",
+                properties={
+                    "IntegrationInstance": instance_identifier,
+                    "ScriptName": "Okta_Disable User",
+                    "ScriptParametersEntityFields": json.dumps(script_params)
+                }
+            )
+    
+            try:
+                execution_response = await bindings.http_client.post(
+                    Endpoints.EXECUTE_MANUAL_ACTION,
+                    req=action_data.model_dump()
+                )
+                return execution_response
+            except Exception as e:
+                print(f"Error executing action Okta_Disable User for Okta: {e}")
+                return {"Status": "Failed", "Message": f"Error executing action: {e}"}
+        else:
+            print(f"Warning: No active integration instance found for Okta")
+            return {"Status": "Failed", "Message": "No active instance found."}
+
+    @mcp.tool()
+    async def okta_get_user(case_id: Annotated[str, Field(..., description="The ID of the case.")], alert_group_identifiers: Annotated[List[str], Field(..., description="Identifiers for the alert groups.")], user_ids_or_logins: Annotated[str, Field(default=None, description="Ids or logins (email or short email name) of a user in Okta, e.g. test@gmail.com or simply 'test'")], also_run_on_scope: Annotated[bool, Field(default=None, description="Whether to run on entities as well as the input")], target_entities: Annotated[List[TargetEntity], Field(default_factory=list, description="Optional list of specific target entities (Identifier, EntityType) to run the action on.")], scope: Annotated[str, Field(default="All entities", description="Defines the scope for the action.")]) -> dict:
+        """
+Get information about a user
+
+Action Parameters: User IDs Or Logins: IDs or logins (email or short email name) of a user in Okta, for example: test@gmail.com or simply 'test'., Also Run On Scope: Whether to run on entities as well as the input.
+
+Returns:
+dict: A dictionary containing the result of the action execution.
+"""
+        final_target_entities: Optional[List[TargetEntity]] = None
+        final_scope: Optional[str] = None
+        is_predefined_scope: Optional[bool] = None
+    
+        if target_entities:
+            # Specific target entities provided, ignore scope parameter
+            final_target_entities = target_entities
+            final_scope = None
+            is_predefined_scope = False
+        else:
+            # Check if the provided scope is valid
+            if scope not in bindings.valid_scopes:
+                allowed_values_str = ", ".join(sorted(list(bindings.valid_scopes)))
+                return {
+                    "Status": "Failed",
+                    "Message": f"Invalid scope '{scope}'. Allowed values are: {allowed_values_str}",
+                }
+            final_target_entities = [] # Pass empty list for entities when using scope
+            final_scope = scope
+            is_predefined_scope = True
+    
+        # Fetch integration instance identifier
+        try:
+            instance_response = await bindings.http_client.get(
+                Endpoints.LIST_INTEGRATION_INSTANCES.format(INTEGRATION_NAME="Okta")
+            )
+            instances = instance_response.get("integration_instances", [])
+        except Exception as e:
+            print(f"Error fetching instance for Okta: {e}")
+            return {"Status": "Failed", "Message": f"Error fetching instance: {e}"}
+    
+        if instances:
+            instance_identifier = instances[0].get("identifier")
+            if not instance_identifier:
+                return {"Status": "Failed", "Message": "Instance found but identifier is missing."}
+    
+            script_params = {}
+            if user_ids_or_logins is not None:
+                script_params["User Ids Or Logins"] = user_ids_or_logins
+            if also_run_on_scope is not None:
+                script_params["Also Run On Scope"] = also_run_on_scope
+    
+            # Prepare data model for the API request
+            action_data = ApiManualActionDataModel(
+                alertGroupIdentifiers=alert_group_identifiers,
+                caseId=case_id,
+                targetEntities=final_target_entities,
+                scope=final_scope,
+                isPredefinedScope=is_predefined_scope,
+                actionProvider="Scripts",
+                actionName="Okta_Get User",
+                properties={
+                    "IntegrationInstance": instance_identifier,
+                    "ScriptName": "Okta_Get User",
+                    "ScriptParametersEntityFields": json.dumps(script_params)
+                }
+            )
+    
+            try:
+                execution_response = await bindings.http_client.post(
+                    Endpoints.EXECUTE_MANUAL_ACTION,
+                    req=action_data.model_dump()
+                )
+                return execution_response
+            except Exception as e:
+                print(f"Error executing action Okta_Get User for Okta: {e}")
+                return {"Status": "Failed", "Message": f"Error executing action: {e}"}
+        else:
+            print(f"Warning: No active integration instance found for Okta")
+            return {"Status": "Failed", "Message": "No active instance found."}
+
+    @mcp.tool()
+    async def okta_ping(case_id: Annotated[str, Field(..., description="The ID of the case.")], alert_group_identifiers: Annotated[List[str], Field(..., description="Identifiers for the alert groups.")], target_entities: Annotated[List[TargetEntity], Field(default_factory=list, description="Optional list of specific target entities (Identifier, EntityType) to run the action on.")], scope: Annotated[str, Field(default="All entities", description="Defines the scope for the action.")]) -> dict:
+        """Test Connection With Okta
+
+        Returns:
+            dict: A dictionary containing the result of the action execution.
+        """
+        final_target_entities: Optional[List[TargetEntity]] = None
+        final_scope: Optional[str] = None
+        is_predefined_scope: Optional[bool] = None
+    
+        if target_entities:
+            # Specific target entities provided, ignore scope parameter
+            final_target_entities = target_entities
+            final_scope = None
+            is_predefined_scope = False
+        else:
+            # Check if the provided scope is valid
+            if scope not in bindings.valid_scopes:
+                allowed_values_str = ", ".join(sorted(list(bindings.valid_scopes)))
+                return {
+                    "Status": "Failed",
+                    "Message": f"Invalid scope '{scope}'. Allowed values are: {allowed_values_str}",
+                }
+            final_target_entities = [] # Pass empty list for entities when using scope
+            final_scope = scope
+            is_predefined_scope = True
+    
+        # Fetch integration instance identifier
+        try:
+            instance_response = await bindings.http_client.get(
+                Endpoints.LIST_INTEGRATION_INSTANCES.format(INTEGRATION_NAME="Okta")
+            )
+            instances = instance_response.get("integration_instances", [])
+        except Exception as e:
+            print(f"Error fetching instance for Okta: {e}")
+            return {"Status": "Failed", "Message": f"Error fetching instance: {e}"}
+    
+        if instances:
+            instance_identifier = instances[0].get("identifier")
+            if not instance_identifier:
+                return {"Status": "Failed", "Message": "Instance found but identifier is missing."}
+    
+            script_params = {}
+    
+            # Prepare data model for the API request
+            action_data = ApiManualActionDataModel(
+                alertGroupIdentifiers=alert_group_identifiers,
+                caseId=case_id,
+                targetEntities=final_target_entities,
+                scope=final_scope,
+                isPredefinedScope=is_predefined_scope,
+                actionProvider="Scripts",
+                actionName="Okta_Ping",
+                properties={
+                    "IntegrationInstance": instance_identifier,
+                    "ScriptName": "Okta_Ping",
+                    "ScriptParametersEntityFields": json.dumps(script_params)
+                }
+            )
+    
+            try:
+                execution_response = await bindings.http_client.post(
+                    Endpoints.EXECUTE_MANUAL_ACTION,
+                    req=action_data.model_dump()
+                )
+                return execution_response
+            except Exception as e:
+                print(f"Error executing action Okta_Ping for Okta: {e}")
+                return {"Status": "Failed", "Message": f"Error executing action: {e}"}
+        else:
+            print(f"Warning: No active integration instance found for Okta")
+            return {"Status": "Failed", "Message": "No active instance found."}
+
+    @mcp.tool()
+    async def okta_list_user_groups(case_id: Annotated[str, Field(..., description="The ID of the case.")], alert_group_identifiers: Annotated[List[str], Field(..., description="Identifiers for the alert groups.")], user_i_ds_or_logins: Annotated[str, Field(default=None, description="Ids or logins of users in Okta")], also_run_on_scope: Annotated[bool, Field(default=None, description="Whether to run on entities as well as the input")], target_entities: Annotated[List[TargetEntity], Field(default_factory=list, description="Optional list of specific target entities (Identifier, EntityType) to run the action on.")], scope: Annotated[str, Field(default="All entities", description="Defines the scope for the action.")]) -> dict:
+        """
+Get the groups that the user is a member of
+
+Action Parameters: User IDs Or Logins: IDs or logins of users in Okta., Also Run On Scope: Whether to run on entities as well as the input.
+
+Returns:
+dict: A dictionary containing the result of the action execution.
+"""
+        final_target_entities: Optional[List[TargetEntity]] = None
+        final_scope: Optional[str] = None
+        is_predefined_scope: Optional[bool] = None
+    
+        if target_entities:
+            # Specific target entities provided, ignore scope parameter
+            final_target_entities = target_entities
+            final_scope = None
+            is_predefined_scope = False
+        else:
+            # Check if the provided scope is valid
+            if scope not in bindings.valid_scopes:
+                allowed_values_str = ", ".join(sorted(list(bindings.valid_scopes)))
+                return {
+                    "Status": "Failed",
+                    "Message": f"Invalid scope '{scope}'. Allowed values are: {allowed_values_str}",
+                }
+            final_target_entities = [] # Pass empty list for entities when using scope
+            final_scope = scope
+            is_predefined_scope = True
+    
+        # Fetch integration instance identifier
+        try:
+            instance_response = await bindings.http_client.get(
+                Endpoints.LIST_INTEGRATION_INSTANCES.format(INTEGRATION_NAME="Okta")
+            )
+            instances = instance_response.get("integration_instances", [])
+        except Exception as e:
+            print(f"Error fetching instance for Okta: {e}")
+            return {"Status": "Failed", "Message": f"Error fetching instance: {e}"}
+    
+        if instances:
+            instance_identifier = instances[0].get("identifier")
+            if not instance_identifier:
+                return {"Status": "Failed", "Message": "Instance found but identifier is missing."}
+    
+            script_params = {}
+            if user_i_ds_or_logins is not None:
+                script_params["User IDs Or Logins"] = user_i_ds_or_logins
+            if also_run_on_scope is not None:
+                script_params["Also Run On Scope"] = also_run_on_scope
+    
+            # Prepare data model for the API request
+            action_data = ApiManualActionDataModel(
+                alertGroupIdentifiers=alert_group_identifiers,
+                caseId=case_id,
+                targetEntities=final_target_entities,
+                scope=final_scope,
+                isPredefinedScope=is_predefined_scope,
+                actionProvider="Scripts",
+                actionName="Okta_List User Groups",
+                properties={
+                    "IntegrationInstance": instance_identifier,
+                    "ScriptName": "Okta_List User Groups",
+                    "ScriptParametersEntityFields": json.dumps(script_params)
+                }
+            )
+    
+            try:
+                execution_response = await bindings.http_client.post(
+                    Endpoints.EXECUTE_MANUAL_ACTION,
+                    req=action_data.model_dump()
+                )
+                return execution_response
+            except Exception as e:
+                print(f"Error executing action Okta_List User Groups for Okta: {e}")
+                return {"Status": "Failed", "Message": f"Error executing action: {e}"}
+        else:
+            print(f"Warning: No active integration instance found for Okta")
+            return {"Status": "Failed", "Message": "No active instance found."}
+
+    @mcp.tool()
+    async def okta_get_group(case_id: Annotated[str, Field(..., description="The ID of the case.")], alert_group_identifiers: Annotated[List[str], Field(..., description="Identifiers for the alert groups.")], group_ids_or_names: Annotated[str, Field(..., description="Ids or names of groups in Okta")], is_id: Annotated[bool, Field(default=None, description="Whether the value is an id or a name")], target_entities: Annotated[List[TargetEntity], Field(default_factory=list, description="Optional list of specific target entities (Identifier, EntityType) to run the action on.")], scope: Annotated[str, Field(default="All entities", description="Defines the scope for the action.")]) -> dict:
+        """
+Get information about a group
+
+Action Parameters: Group IDs Or Names: IDs or names of groups in Okta., Is Id: Whether the value is an ID or a name.
+
+Returns:
+dict: A dictionary containing the result of the action execution.
+"""
+        final_target_entities: Optional[List[TargetEntity]] = None
+        final_scope: Optional[str] = None
+        is_predefined_scope: Optional[bool] = None
+    
+        if target_entities:
+            # Specific target entities provided, ignore scope parameter
+            final_target_entities = target_entities
+            final_scope = None
+            is_predefined_scope = False
+        else:
+            # Check if the provided scope is valid
+            if scope not in bindings.valid_scopes:
+                allowed_values_str = ", ".join(sorted(list(bindings.valid_scopes)))
+                return {
+                    "Status": "Failed",
+                    "Message": f"Invalid scope '{scope}'. Allowed values are: {allowed_values_str}",
+                }
+            final_target_entities = [] # Pass empty list for entities when using scope
+            final_scope = scope
+            is_predefined_scope = True
+    
+        # Fetch integration instance identifier
+        try:
+            instance_response = await bindings.http_client.get(
+                Endpoints.LIST_INTEGRATION_INSTANCES.format(INTEGRATION_NAME="Okta")
+            )
+            instances = instance_response.get("integration_instances", [])
+        except Exception as e:
+            print(f"Error fetching instance for Okta: {e}")
+            return {"Status": "Failed", "Message": f"Error fetching instance: {e}"}
+    
+        if instances:
+            instance_identifier = instances[0].get("identifier")
+            if not instance_identifier:
+                return {"Status": "Failed", "Message": "Instance found but identifier is missing."}
+    
+            script_params = {}
+            script_params["Group Ids Or Names"] = group_ids_or_names
+            if is_id is not None:
+                script_params["Is Id"] = is_id
+    
+            # Prepare data model for the API request
+            action_data = ApiManualActionDataModel(
+                alertGroupIdentifiers=alert_group_identifiers,
+                caseId=case_id,
+                targetEntities=final_target_entities,
+                scope=final_scope,
+                isPredefinedScope=is_predefined_scope,
+                actionProvider="Scripts",
+                actionName="Okta_Get Group",
+                properties={
+                    "IntegrationInstance": instance_identifier,
+                    "ScriptName": "Okta_Get Group",
+                    "ScriptParametersEntityFields": json.dumps(script_params)
+                }
+            )
+    
+            try:
+                execution_response = await bindings.http_client.post(
+                    Endpoints.EXECUTE_MANUAL_ACTION,
+                    req=action_data.model_dump()
+                )
+                return execution_response
+            except Exception as e:
+                print(f"Error executing action Okta_Get Group for Okta: {e}")
+                return {"Status": "Failed", "Message": f"Error executing action: {e}"}
+        else:
+            print(f"Warning: No active integration instance found for Okta")
+            return {"Status": "Failed", "Message": "No active instance found."}
+
+    @mcp.tool()
+    async def okta_add_group(case_id: Annotated[str, Field(..., description="The ID of the case.")], alert_group_identifiers: Annotated[List[str], Field(..., description="Identifiers for the alert groups.")], group_name: Annotated[str, Field(..., description="The name of the group in Okta")], group_description: Annotated[str, Field(default=None, description="The description for the group")], target_entities: Annotated[List[TargetEntity], Field(default_factory=list, description="Optional list of specific target entities (Identifier, EntityType) to run the action on.")], scope: Annotated[str, Field(default="All entities", description="Defines the scope for the action.")]) -> dict:
+        """Add a group
+
+        Returns:
+            dict: A dictionary containing the result of the action execution.
+        """
+        final_target_entities: Optional[List[TargetEntity]] = None
+        final_scope: Optional[str] = None
+        is_predefined_scope: Optional[bool] = None
+    
+        if target_entities:
+            # Specific target entities provided, ignore scope parameter
+            final_target_entities = target_entities
+            final_scope = None
+            is_predefined_scope = False
+        else:
+            # Check if the provided scope is valid
+            if scope not in bindings.valid_scopes:
+                allowed_values_str = ", ".join(sorted(list(bindings.valid_scopes)))
+                return {
+                    "Status": "Failed",
+                    "Message": f"Invalid scope '{scope}'. Allowed values are: {allowed_values_str}",
+                }
+            final_target_entities = [] # Pass empty list for entities when using scope
+            final_scope = scope
+            is_predefined_scope = True
+    
+        # Fetch integration instance identifier
+        try:
+            instance_response = await bindings.http_client.get(
+                Endpoints.LIST_INTEGRATION_INSTANCES.format(INTEGRATION_NAME="Okta")
+            )
+            instances = instance_response.get("integration_instances", [])
+        except Exception as e:
+            print(f"Error fetching instance for Okta: {e}")
+            return {"Status": "Failed", "Message": f"Error fetching instance: {e}"}
+    
+        if instances:
+            instance_identifier = instances[0].get("identifier")
+            if not instance_identifier:
+                return {"Status": "Failed", "Message": "Instance found but identifier is missing."}
+    
+            script_params = {}
+            script_params["Group Name"] = group_name
+            if group_description is not None:
+                script_params["Group Description"] = group_description
+    
+            # Prepare data model for the API request
+            action_data = ApiManualActionDataModel(
+                alertGroupIdentifiers=alert_group_identifiers,
+                caseId=case_id,
+                targetEntities=final_target_entities,
+                scope=final_scope,
+                isPredefinedScope=is_predefined_scope,
+                actionProvider="Scripts",
+                actionName="Okta_Add Group",
+                properties={
+                    "IntegrationInstance": instance_identifier,
+                    "ScriptName": "Okta_Add Group",
+                    "ScriptParametersEntityFields": json.dumps(script_params)
+                }
+            )
+    
+            try:
+                execution_response = await bindings.http_client.post(
+                    Endpoints.EXECUTE_MANUAL_ACTION,
+                    req=action_data.model_dump()
+                )
+                return execution_response
+            except Exception as e:
+                print(f"Error executing action Okta_Add Group for Okta: {e}")
+                return {"Status": "Failed", "Message": f"Error executing action: {e}"}
+        else:
+            print(f"Warning: No active integration instance found for Okta")
+            return {"Status": "Failed", "Message": "No active instance found."}
+
+    @mcp.tool()
+    async def okta_reset_password(case_id: Annotated[str, Field(..., description="The ID of the case.")], alert_group_identifiers: Annotated[List[str], Field(..., description="Identifiers for the alert groups.")], user_i_ds_or_logins: Annotated[str, Field(default=None, description="Ids or logins of users in Okta")], send_email: Annotated[bool, Field(default=None, description="Whether to send an email for the password reset or return the token for every user")], also_run_on_scope: Annotated[bool, Field(default=None, description="Whether to run on entities as well as the input")], target_entities: Annotated[List[TargetEntity], Field(default_factory=list, description="Optional list of specific target entities (Identifier, EntityType) to run the action on.")], scope: Annotated[str, Field(default="All entities", description="Defines the scope for the action.")]) -> dict:
+        """
+Generate a one-time token that can be used to reset a user's password
+
+Action Parameters: User IDs Or Logins: IDs or logins of users in Okta., Send Email: Whether to send an email for the password reset or return the token for every user., Also Run On Scope: Whether to run on entities as well as the input.
+
+Returns:
+dict: A dictionary containing the result of the action execution.
+"""
+        final_target_entities: Optional[List[TargetEntity]] = None
+        final_scope: Optional[str] = None
+        is_predefined_scope: Optional[bool] = None
+    
+        if target_entities:
+            # Specific target entities provided, ignore scope parameter
+            final_target_entities = target_entities
+            final_scope = None
+            is_predefined_scope = False
+        else:
+            # Check if the provided scope is valid
+            if scope not in bindings.valid_scopes:
+                allowed_values_str = ", ".join(sorted(list(bindings.valid_scopes)))
+                return {
+                    "Status": "Failed",
+                    "Message": f"Invalid scope '{scope}'. Allowed values are: {allowed_values_str}",
+                }
+            final_target_entities = [] # Pass empty list for entities when using scope
+            final_scope = scope
+            is_predefined_scope = True
+    
+        # Fetch integration instance identifier
+        try:
+            instance_response = await bindings.http_client.get(
+                Endpoints.LIST_INTEGRATION_INSTANCES.format(INTEGRATION_NAME="Okta")
+            )
+            instances = instance_response.get("integration_instances", [])
+        except Exception as e:
+            print(f"Error fetching instance for Okta: {e}")
+            return {"Status": "Failed", "Message": f"Error fetching instance: {e}"}
+    
+        if instances:
+            instance_identifier = instances[0].get("identifier")
+            if not instance_identifier:
+                return {"Status": "Failed", "Message": "Instance found but identifier is missing."}
+    
+            script_params = {}
+            if user_i_ds_or_logins is not None:
+                script_params["User IDs Or Logins"] = user_i_ds_or_logins
+            if send_email is not None:
+                script_params["Send Email"] = send_email
+            if also_run_on_scope is not None:
+                script_params["Also Run On Scope"] = also_run_on_scope
+    
+            # Prepare data model for the API request
+            action_data = ApiManualActionDataModel(
+                alertGroupIdentifiers=alert_group_identifiers,
+                caseId=case_id,
+                targetEntities=final_target_entities,
+                scope=final_scope,
+                isPredefinedScope=is_predefined_scope,
+                actionProvider="Scripts",
+                actionName="Okta_Reset Password",
+                properties={
+                    "IntegrationInstance": instance_identifier,
+                    "ScriptName": "Okta_Reset Password",
+                    "ScriptParametersEntityFields": json.dumps(script_params)
+                }
+            )
+    
+            try:
+                execution_response = await bindings.http_client.post(
+                    Endpoints.EXECUTE_MANUAL_ACTION,
+                    req=action_data.model_dump()
+                )
+                return execution_response
+            except Exception as e:
+                print(f"Error executing action Okta_Reset Password for Okta: {e}")
+                return {"Status": "Failed", "Message": f"Error executing action: {e}"}
+        else:
+            print(f"Warning: No active integration instance found for Okta")
+            return {"Status": "Failed", "Message": "No active instance found."}
+
+    @mcp.tool()
+    async def okta_list_roles(case_id: Annotated[str, Field(..., description="The ID of the case.")], alert_group_identifiers: Annotated[List[str], Field(..., description="Identifiers for the alert groups.")], user_i_ds: Annotated[str, Field(default=None, description="Ids of users in Okta")], also_run_on_scope: Annotated[bool, Field(default=None, description="Whether to run on entities as well as the input")], target_entities: Annotated[List[TargetEntity], Field(default_factory=list, description="Optional list of specific target entities (Identifier, EntityType) to run the action on.")], scope: Annotated[str, Field(default="All entities", description="Defines the scope for the action.")]) -> dict:
+        """Lists all roles assigned to a user
+
+        Returns:
+            dict: A dictionary containing the result of the action execution.
+        """
+        final_target_entities: Optional[List[TargetEntity]] = None
+        final_scope: Optional[str] = None
+        is_predefined_scope: Optional[bool] = None
+    
+        if target_entities:
+            # Specific target entities provided, ignore scope parameter
+            final_target_entities = target_entities
+            final_scope = None
+            is_predefined_scope = False
+        else:
+            # Check if the provided scope is valid
+            if scope not in bindings.valid_scopes:
+                allowed_values_str = ", ".join(sorted(list(bindings.valid_scopes)))
+                return {
+                    "Status": "Failed",
+                    "Message": f"Invalid scope '{scope}'. Allowed values are: {allowed_values_str}",
+                }
+            final_target_entities = [] # Pass empty list for entities when using scope
+            final_scope = scope
+            is_predefined_scope = True
+    
+        # Fetch integration instance identifier
+        try:
+            instance_response = await bindings.http_client.get(
+                Endpoints.LIST_INTEGRATION_INSTANCES.format(INTEGRATION_NAME="Okta")
+            )
+            instances = instance_response.get("integration_instances", [])
+        except Exception as e:
+            print(f"Error fetching instance for Okta: {e}")
+            return {"Status": "Failed", "Message": f"Error fetching instance: {e}"}
+    
+        if instances:
+            instance_identifier = instances[0].get("identifier")
+            if not instance_identifier:
+                return {"Status": "Failed", "Message": "Instance found but identifier is missing."}
+    
+            script_params = {}
+            if user_i_ds is not None:
+                script_params["User IDs"] = user_i_ds
+            if also_run_on_scope is not None:
+                script_params["Also Run On Scope"] = also_run_on_scope
+    
+            # Prepare data model for the API request
+            action_data = ApiManualActionDataModel(
+                alertGroupIdentifiers=alert_group_identifiers,
+                caseId=case_id,
+                targetEntities=final_target_entities,
+                scope=final_scope,
+                isPredefinedScope=is_predefined_scope,
+                actionProvider="Scripts",
+                actionName="Okta_List Roles",
+                properties={
+                    "IntegrationInstance": instance_identifier,
+                    "ScriptName": "Okta_List Roles",
+                    "ScriptParametersEntityFields": json.dumps(script_params)
+                }
+            )
+    
+            try:
+                execution_response = await bindings.http_client.post(
+                    Endpoints.EXECUTE_MANUAL_ACTION,
+                    req=action_data.model_dump()
+                )
+                return execution_response
+            except Exception as e:
+                print(f"Error executing action Okta_List Roles for Okta: {e}")
+                return {"Status": "Failed", "Message": f"Error executing action: {e}"}
+        else:
+            print(f"Warning: No active integration instance found for Okta")
+            return {"Status": "Failed", "Message": "No active instance found."}
+
+    @mcp.tool()
+    async def okta_enable_user(case_id: Annotated[str, Field(..., description="The ID of the case.")], alert_group_identifiers: Annotated[List[str], Field(..., description="Identifiers for the alert groups.")], user_i_ds_or_logins: Annotated[str, Field(default=None, description="Ids or logins of users in Okta")], is_activate: Annotated[bool, Field(default=None, description="Whether to activate the user or just unsuspend")], send_email_if_activate: Annotated[bool, Field(default=None, description="Whether to send an email after activating or not")], also_run_on_scope: Annotated[bool, Field(default=None, description="Whether to run on entities as well as the input")], target_entities: Annotated[List[TargetEntity], Field(default_factory=list, description="Optional list of specific target entities (Identifier, EntityType) to run the action on.")], scope: Annotated[str, Field(default="All entities", description="Defines the scope for the action.")]) -> dict:
+        """
+Enables the specified user
+
+Action Parameters: User IDs Or Logins: IDs or logins of users in Okta., Is Activate: Whether to activate the user or just unsuspend., Send Email If Activate: Whether to send an email after activating or not., Also Run On Scope: Whether to run on entities as well as the input.
+
+Returns:
+dict: A dictionary containing the result of the action execution.
+"""
+        final_target_entities: Optional[List[TargetEntity]] = None
+        final_scope: Optional[str] = None
+        is_predefined_scope: Optional[bool] = None
+    
+        if target_entities:
+            # Specific target entities provided, ignore scope parameter
+            final_target_entities = target_entities
+            final_scope = None
+            is_predefined_scope = False
+        else:
+            # Check if the provided scope is valid
+            if scope not in bindings.valid_scopes:
+                allowed_values_str = ", ".join(sorted(list(bindings.valid_scopes)))
+                return {
+                    "Status": "Failed",
+                    "Message": f"Invalid scope '{scope}'. Allowed values are: {allowed_values_str}",
+                }
+            final_target_entities = [] # Pass empty list for entities when using scope
+            final_scope = scope
+            is_predefined_scope = True
+    
+        # Fetch integration instance identifier
+        try:
+            instance_response = await bindings.http_client.get(
+                Endpoints.LIST_INTEGRATION_INSTANCES.format(INTEGRATION_NAME="Okta")
+            )
+            instances = instance_response.get("integration_instances", [])
+        except Exception as e:
+            print(f"Error fetching instance for Okta: {e}")
+            return {"Status": "Failed", "Message": f"Error fetching instance: {e}"}
+    
+        if instances:
+            instance_identifier = instances[0].get("identifier")
+            if not instance_identifier:
+                return {"Status": "Failed", "Message": "Instance found but identifier is missing."}
+    
+            script_params = {}
+            if user_i_ds_or_logins is not None:
+                script_params["User IDs Or Logins"] = user_i_ds_or_logins
+            if is_activate is not None:
+                script_params["Is Activate"] = is_activate
+            if send_email_if_activate is not None:
+                script_params["Send Email If Activate"] = send_email_if_activate
+            if also_run_on_scope is not None:
+                script_params["Also Run On Scope"] = also_run_on_scope
+    
+            # Prepare data model for the API request
+            action_data = ApiManualActionDataModel(
+                alertGroupIdentifiers=alert_group_identifiers,
+                caseId=case_id,
+                targetEntities=final_target_entities,
+                scope=final_scope,
+                isPredefinedScope=is_predefined_scope,
+                actionProvider="Scripts",
+                actionName="Okta_Enable User",
+                properties={
+                    "IntegrationInstance": instance_identifier,
+                    "ScriptName": "Okta_Enable User",
+                    "ScriptParametersEntityFields": json.dumps(script_params)
+                }
+            )
+    
+            try:
+                execution_response = await bindings.http_client.post(
+                    Endpoints.EXECUTE_MANUAL_ACTION,
+                    req=action_data.model_dump()
+                )
+                return execution_response
+            except Exception as e:
+                print(f"Error executing action Okta_Enable User for Okta: {e}")
+                return {"Status": "Failed", "Message": f"Error executing action: {e}"}
+        else:
+            print(f"Warning: No active integration instance found for Okta")
+            return {"Status": "Failed", "Message": "No active instance found."}
+
+    @mcp.tool()
+    async def okta_set_password(case_id: Annotated[str, Field(..., description="The ID of the case.")], alert_group_identifiers: Annotated[List[str], Field(..., description="Identifiers for the alert groups.")], new_password: Annotated[str, Field(..., description="The new password")], user_i_ds_or_logins: Annotated[str, Field(default=None, description="Ids or logins of users in Okta")], add_10_random_chars: Annotated[bool, Field(default=None, description="Whether to add extra characters to every user password or not")], also_run_on_scope: Annotated[bool, Field(default=None, description="Whether to run on entities as well as the input")], target_entities: Annotated[List[TargetEntity], Field(default_factory=list, description="Optional list of specific target entities (Identifier, EntityType) to run the action on.")], scope: Annotated[str, Field(default="All entities", description="Defines the scope for the action.")]) -> dict:
+        """
+Set the password of a user without validating existing credentials
+
+Action Parameters: User IDs Or Logins: IDs or logins of users in Okta., New Password: The new password., Add 10 Random Chars: Whether to add extra characters to every user password or not., Also Run On Scope: Whether to run on entities as well as the input.
+
+Returns:
+dict: A dictionary containing the result of the action execution.
+"""
+        final_target_entities: Optional[List[TargetEntity]] = None
+        final_scope: Optional[str] = None
+        is_predefined_scope: Optional[bool] = None
+    
+        if target_entities:
+            # Specific target entities provided, ignore scope parameter
+            final_target_entities = target_entities
+            final_scope = None
+            is_predefined_scope = False
+        else:
+            # Check if the provided scope is valid
+            if scope not in bindings.valid_scopes:
+                allowed_values_str = ", ".join(sorted(list(bindings.valid_scopes)))
+                return {
+                    "Status": "Failed",
+                    "Message": f"Invalid scope '{scope}'. Allowed values are: {allowed_values_str}",
+                }
+            final_target_entities = [] # Pass empty list for entities when using scope
+            final_scope = scope
+            is_predefined_scope = True
+    
+        # Fetch integration instance identifier
+        try:
+            instance_response = await bindings.http_client.get(
+                Endpoints.LIST_INTEGRATION_INSTANCES.format(INTEGRATION_NAME="Okta")
+            )
+            instances = instance_response.get("integration_instances", [])
+        except Exception as e:
+            print(f"Error fetching instance for Okta: {e}")
+            return {"Status": "Failed", "Message": f"Error fetching instance: {e}"}
+    
+        if instances:
+            instance_identifier = instances[0].get("identifier")
+            if not instance_identifier:
+                return {"Status": "Failed", "Message": "Instance found but identifier is missing."}
+    
+            script_params = {}
+            if user_i_ds_or_logins is not None:
+                script_params["User IDs Or Logins"] = user_i_ds_or_logins
+            script_params["New Password"] = new_password
+            if add_10_random_chars is not None:
+                script_params["Add 10 Random Chars"] = add_10_random_chars
+            if also_run_on_scope is not None:
+                script_params["Also Run On Scope"] = also_run_on_scope
+    
+            # Prepare data model for the API request
+            action_data = ApiManualActionDataModel(
+                alertGroupIdentifiers=alert_group_identifiers,
+                caseId=case_id,
+                targetEntities=final_target_entities,
+                scope=final_scope,
+                isPredefinedScope=is_predefined_scope,
+                actionProvider="Scripts",
+                actionName="Okta_Set Password",
+                properties={
+                    "IntegrationInstance": instance_identifier,
+                    "ScriptName": "Okta_Set Password",
+                    "ScriptParametersEntityFields": json.dumps(script_params)
+                }
+            )
+    
+            try:
+                execution_response = await bindings.http_client.post(
+                    Endpoints.EXECUTE_MANUAL_ACTION,
+                    req=action_data.model_dump()
+                )
+                return execution_response
+            except Exception as e:
+                print(f"Error executing action Okta_Set Password for Okta: {e}")
+                return {"Status": "Failed", "Message": f"Error executing action: {e}"}
+        else:
+            print(f"Warning: No active integration instance found for Okta")
+            return {"Status": "Failed", "Message": "No active instance found."}
+
+    @mcp.tool()
+    async def okta_list_users(case_id: Annotated[str, Field(..., description="The ID of the case.")], alert_group_identifiers: Annotated[List[str], Field(..., description="Identifiers for the alert groups.")], query: Annotated[str, Field(default=None, description="Search for a match in the firstname, lastname or in the email")], filter: Annotated[str, Field(default=None, description="Custom search query for a subset of properties")], search: Annotated[str, Field(default=None, description="Custom search query for most properties")], limit: Annotated[str, Field(default=None, description="Max amount of results to return")], target_entities: Annotated[List[TargetEntity], Field(default_factory=list, description="Optional list of specific target entities (Identifier, EntityType) to run the action on.")], scope: Annotated[str, Field(default="All entities", description="Defines the scope for the action.")]) -> dict:
+        """
+Get the list of users
+
+Action Parameters: Query: Search for a match in the firstname, lastname or in the email., Filter: Custom search query for a subset of properties., Search: Custom search query for most properties., Limit: Max amount of results to return.
+
+Returns:
+dict: A dictionary containing the result of the action execution.
+"""
+        final_target_entities: Optional[List[TargetEntity]] = None
+        final_scope: Optional[str] = None
+        is_predefined_scope: Optional[bool] = None
+    
+        if target_entities:
+            # Specific target entities provided, ignore scope parameter
+            final_target_entities = target_entities
+            final_scope = None
+            is_predefined_scope = False
+        else:
+            # Check if the provided scope is valid
+            if scope not in bindings.valid_scopes:
+                allowed_values_str = ", ".join(sorted(list(bindings.valid_scopes)))
+                return {
+                    "Status": "Failed",
+                    "Message": f"Invalid scope '{scope}'. Allowed values are: {allowed_values_str}",
+                }
+            final_target_entities = [] # Pass empty list for entities when using scope
+            final_scope = scope
+            is_predefined_scope = True
+    
+        # Fetch integration instance identifier
+        try:
+            instance_response = await bindings.http_client.get(
+                Endpoints.LIST_INTEGRATION_INSTANCES.format(INTEGRATION_NAME="Okta")
+            )
+            instances = instance_response.get("integration_instances", [])
+        except Exception as e:
+            print(f"Error fetching instance for Okta: {e}")
+            return {"Status": "Failed", "Message": f"Error fetching instance: {e}"}
+    
+        if instances:
+            instance_identifier = instances[0].get("identifier")
+            if not instance_identifier:
+                return {"Status": "Failed", "Message": "Instance found but identifier is missing."}
+    
+            script_params = {}
+            if query is not None:
+                script_params["Query"] = query
+            if filter is not None:
+                script_params["Filter"] = filter
+            if search is not None:
+                script_params["Search"] = search
+            if limit is not None:
+                script_params["Limit"] = limit
+    
+            # Prepare data model for the API request
+            action_data = ApiManualActionDataModel(
+                alertGroupIdentifiers=alert_group_identifiers,
+                caseId=case_id,
+                targetEntities=final_target_entities,
+                scope=final_scope,
+                isPredefinedScope=is_predefined_scope,
+                actionProvider="Scripts",
+                actionName="Okta_List Users",
+                properties={
+                    "IntegrationInstance": instance_identifier,
+                    "ScriptName": "Okta_List Users",
+                    "ScriptParametersEntityFields": json.dumps(script_params)
+                }
+            )
+    
+            try:
+                execution_response = await bindings.http_client.post(
+                    Endpoints.EXECUTE_MANUAL_ACTION,
+                    req=action_data.model_dump()
+                )
+                return execution_response
+            except Exception as e:
+                print(f"Error executing action Okta_List Users for Okta: {e}")
+                return {"Status": "Failed", "Message": f"Error executing action: {e}"}
+        else:
+            print(f"Warning: No active integration instance found for Okta")
+            return {"Status": "Failed", "Message": "No active instance found."}

--- a/mcp_marketplace/okta_session.py
+++ b/mcp_marketplace/okta_session.py
@@ -1,0 +1,50 @@
+"""Utility for retrieving and caching Okta OAuth tokens."""
+
+from __future__ import annotations
+
+import os
+import time
+from typing import Optional
+import requests
+
+
+class OktaSession:
+    """Simple helper for managing an Okta OAuth access token."""
+
+    def __init__(self, issuer_url: str, client_id: str, refresh_token: str) -> None:
+        self.issuer_url = issuer_url.rstrip("/")
+        self.client_id = client_id
+        self.refresh_token = refresh_token
+        self._access_token: Optional[str] = None
+        self._expires_at: float = 0
+
+    def token(self) -> str:
+        """Return a valid access token, refreshing if needed."""
+        if not self._access_token or time.time() >= self._expires_at:
+            self._refresh()
+        assert self._access_token
+        return self._access_token
+
+    def _refresh(self) -> None:
+        token_url = f"{self.issuer_url}/v1/token"
+        resp = requests.post(
+            token_url,
+            data={
+                "grant_type": "refresh_token",
+                "client_id": self.client_id,
+                "refresh_token": self.refresh_token,
+            },
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        self._access_token = data["access_token"]
+        self._expires_at = time.time() + data.get("expires_in", 3600) - 60
+
+
+def from_env() -> Optional[OktaSession]:
+    issuer = os.getenv("OKTA_ISSUER")
+    client_id = os.getenv("OKTA_CLIENT_ID")
+    refresh_token = os.getenv("OKTA_REFRESH_TOKEN")
+    if issuer and client_id and refresh_token:
+        return OktaSession(issuer, client_id, refresh_token)
+    return None

--- a/mcp_marketplace/registry.py
+++ b/mcp_marketplace/registry.py
@@ -1,0 +1,16 @@
+from mcp.server.fastmcp import FastMCP
+
+from . import hashicorpvault, okta, ssh, zendesk
+
+CLIENT_MODULES = [
+    hashicorpvault,
+    okta,
+    ssh,
+    zendesk,
+]
+
+def register_all_tools(mcp: FastMCP) -> None:
+    """Register tools from all included clients."""
+    for module in CLIENT_MODULES:
+        if hasattr(module, "register_tools"):
+            module.register_tools(mcp)

--- a/mcp_marketplace/ssh.py
+++ b/mcp_marketplace/ssh.py
@@ -1,0 +1,1006 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from secops_soar_mcp import bindings
+from mcp.server.fastmcp import FastMCP
+from secops_soar_mcp.utils.consts import Endpoints
+from secops_soar_mcp.utils.models import ApiManualActionDataModel, EmailContent, TargetEntity
+import json
+from typing import Optional, Any, List, Dict, Union, Annotated
+from pydantic import Field
+
+
+def register_tools(mcp: FastMCP):
+    # This function registers all tools (actions) for the SSH integration.
+
+    @mcp.tool()
+    async def ssh_terminate_process(case_id: Annotated[str, Field(..., description="The ID of the case.")], alert_group_identifiers: Annotated[List[str], Field(..., description="Identifiers for the alert groups.")], remote_server: Annotated[str, Field(..., description="Remote server address(e.g: x.x.x.x)")], remote_username: Annotated[str, Field(..., description="")], remote_password: Annotated[str, Field(..., description="")], process: Annotated[str, Field(..., description="Process to terminate.")], remote_port: Annotated[str, Field(default=None, description="")], target_entities: Annotated[List[TargetEntity], Field(default_factory=list, description="Optional list of specific target entities (Identifier, EntityType) to run the action on.")], scope: Annotated[str, Field(default="All entities", description="Defines the scope for the action.")]) -> dict:
+        """Terminate process on a remote machine
+
+        Returns:
+            dict: A dictionary containing the result of the action execution.
+        """
+        final_target_entities: Optional[List[TargetEntity]] = None
+        final_scope: Optional[str] = None
+        is_predefined_scope: Optional[bool] = None
+    
+        if target_entities:
+            # Specific target entities provided, ignore scope parameter
+            final_target_entities = target_entities
+            final_scope = None
+            is_predefined_scope = False
+        else:
+            # Check if the provided scope is valid
+            if scope not in bindings.valid_scopes:
+                allowed_values_str = ", ".join(sorted(list(bindings.valid_scopes)))
+                return {
+                    "Status": "Failed",
+                    "Message": f"Invalid scope '{scope}'. Allowed values are: {allowed_values_str}",
+                }
+            final_target_entities = [] # Pass empty list for entities when using scope
+            final_scope = scope
+            is_predefined_scope = True
+    
+        # Fetch integration instance identifier
+        try:
+            instance_response = await bindings.http_client.get(
+                Endpoints.LIST_INTEGRATION_INSTANCES.format(INTEGRATION_NAME="SSH")
+            )
+            instances = instance_response.get("integration_instances", [])
+        except Exception as e:
+            print(f"Error fetching instance for SSH: {e}")
+            return {"Status": "Failed", "Message": f"Error fetching instance: {e}"}
+    
+        if instances:
+            instance_identifier = instances[0].get("identifier")
+            if not instance_identifier:
+                return {"Status": "Failed", "Message": "Instance found but identifier is missing."}
+    
+            script_params = {}
+            script_params["Remote Server"] = remote_server
+            script_params["Remote Username"] = remote_username
+            script_params["Remote Password"] = remote_password
+            if remote_port is not None:
+                script_params["Remote Port"] = remote_port
+            script_params["PROCESS"] = process
+    
+            # Prepare data model for the API request
+            action_data = ApiManualActionDataModel(
+                alertGroupIdentifiers=alert_group_identifiers,
+                caseId=case_id,
+                targetEntities=final_target_entities,
+                scope=final_scope,
+                isPredefinedScope=is_predefined_scope,
+                actionProvider="Scripts",
+                actionName="SSH_Terminate Process",
+                properties={
+                    "IntegrationInstance": instance_identifier,
+                    "ScriptName": "SSH_Terminate Process",
+                    "ScriptParametersEntityFields": json.dumps(script_params)
+                }
+            )
+    
+            try:
+                execution_response = await bindings.http_client.post(
+                    Endpoints.EXECUTE_MANUAL_ACTION,
+                    req=action_data.model_dump()
+                )
+                return execution_response
+            except Exception as e:
+                print(f"Error executing action SSH_Terminate Process for SSH: {e}")
+                return {"Status": "Failed", "Message": f"Error executing action: {e}"}
+        else:
+            print(f"Warning: No active integration instance found for SSH")
+            return {"Status": "Failed", "Message": "No active instance found."}
+
+    @mcp.tool()
+    async def ssh_reboot_machine(case_id: Annotated[str, Field(..., description="The ID of the case.")], alert_group_identifiers: Annotated[List[str], Field(..., description="Identifiers for the alert groups.")], remote_server: Annotated[str, Field(..., description="Remote server address(e.g: x.x.x.x).")], remote_username: Annotated[str, Field(..., description="")], remote_password: Annotated[str, Field(..., description="")], remote_port: Annotated[str, Field(default=None, description="The default port will be 22.")], target_entities: Annotated[List[TargetEntity], Field(default_factory=list, description="Optional list of specific target entities (Identifier, EntityType) to run the action on.")], scope: Annotated[str, Field(default="All entities", description="Defines the scope for the action.")]) -> dict:
+        """
+Reboot remote server
+
+Action Parameters: Remote Server: Remote server address (example: x.x.x.x)., Remote Username: , Remote Password: , Remote Port: The default port will be 22.
+
+Returns:
+dict: A dictionary containing the result of the action execution.
+"""
+        final_target_entities: Optional[List[TargetEntity]] = None
+        final_scope: Optional[str] = None
+        is_predefined_scope: Optional[bool] = None
+    
+        if target_entities:
+            # Specific target entities provided, ignore scope parameter
+            final_target_entities = target_entities
+            final_scope = None
+            is_predefined_scope = False
+        else:
+            # Check if the provided scope is valid
+            if scope not in bindings.valid_scopes:
+                allowed_values_str = ", ".join(sorted(list(bindings.valid_scopes)))
+                return {
+                    "Status": "Failed",
+                    "Message": f"Invalid scope '{scope}'. Allowed values are: {allowed_values_str}",
+                }
+            final_target_entities = [] # Pass empty list for entities when using scope
+            final_scope = scope
+            is_predefined_scope = True
+    
+        # Fetch integration instance identifier
+        try:
+            instance_response = await bindings.http_client.get(
+                Endpoints.LIST_INTEGRATION_INSTANCES.format(INTEGRATION_NAME="SSH")
+            )
+            instances = instance_response.get("integration_instances", [])
+        except Exception as e:
+            print(f"Error fetching instance for SSH: {e}")
+            return {"Status": "Failed", "Message": f"Error fetching instance: {e}"}
+    
+        if instances:
+            instance_identifier = instances[0].get("identifier")
+            if not instance_identifier:
+                return {"Status": "Failed", "Message": "Instance found but identifier is missing."}
+    
+            script_params = {}
+            script_params["Remote Server"] = remote_server
+            script_params["Remote Username"] = remote_username
+            script_params["Remote Password"] = remote_password
+            if remote_port is not None:
+                script_params["Remote Port"] = remote_port
+    
+            # Prepare data model for the API request
+            action_data = ApiManualActionDataModel(
+                alertGroupIdentifiers=alert_group_identifiers,
+                caseId=case_id,
+                targetEntities=final_target_entities,
+                scope=final_scope,
+                isPredefinedScope=is_predefined_scope,
+                actionProvider="Scripts",
+                actionName="SSH_Reboot Machine",
+                properties={
+                    "IntegrationInstance": instance_identifier,
+                    "ScriptName": "SSH_Reboot Machine",
+                    "ScriptParametersEntityFields": json.dumps(script_params)
+                }
+            )
+    
+            try:
+                execution_response = await bindings.http_client.post(
+                    Endpoints.EXECUTE_MANUAL_ACTION,
+                    req=action_data.model_dump()
+                )
+                return execution_response
+            except Exception as e:
+                print(f"Error executing action SSH_Reboot Machine for SSH: {e}")
+                return {"Status": "Failed", "Message": f"Error executing action: {e}"}
+        else:
+            print(f"Warning: No active integration instance found for SSH")
+            return {"Status": "Failed", "Message": "No active instance found."}
+
+    @mcp.tool()
+    async def ssh_logoff_user(case_id: Annotated[str, Field(..., description="The ID of the case.")], alert_group_identifiers: Annotated[List[str], Field(..., description="Identifiers for the alert groups.")], remote_server: Annotated[str, Field(..., description="Remote server address(e.g: x.x.x.x)")], remote_username: Annotated[str, Field(..., description="")], remote_password: Annotated[str, Field(..., description="")], logoff_username: Annotated[str, Field(..., description="The username to log off.")], remote_port: Annotated[str, Field(default=None, description="The default port will be 22.")], target_entities: Annotated[List[TargetEntity], Field(default_factory=list, description="Optional list of specific target entities (Identifier, EntityType) to run the action on.")], scope: Annotated[str, Field(default="All entities", description="Defines the scope for the action.")]) -> dict:
+        """
+Log off remote user
+
+Action Parameters: Remote Server: Remote server address (example: x.x.x.x)., Remote Username: , Remote Password: , Remote Port: The default port will be 22., Logoff Username: The username to log off.
+
+Returns:
+dict: A dictionary containing the result of the action execution.
+"""
+        final_target_entities: Optional[List[TargetEntity]] = None
+        final_scope: Optional[str] = None
+        is_predefined_scope: Optional[bool] = None
+    
+        if target_entities:
+            # Specific target entities provided, ignore scope parameter
+            final_target_entities = target_entities
+            final_scope = None
+            is_predefined_scope = False
+        else:
+            # Check if the provided scope is valid
+            if scope not in bindings.valid_scopes:
+                allowed_values_str = ", ".join(sorted(list(bindings.valid_scopes)))
+                return {
+                    "Status": "Failed",
+                    "Message": f"Invalid scope '{scope}'. Allowed values are: {allowed_values_str}",
+                }
+            final_target_entities = [] # Pass empty list for entities when using scope
+            final_scope = scope
+            is_predefined_scope = True
+    
+        # Fetch integration instance identifier
+        try:
+            instance_response = await bindings.http_client.get(
+                Endpoints.LIST_INTEGRATION_INSTANCES.format(INTEGRATION_NAME="SSH")
+            )
+            instances = instance_response.get("integration_instances", [])
+        except Exception as e:
+            print(f"Error fetching instance for SSH: {e}")
+            return {"Status": "Failed", "Message": f"Error fetching instance: {e}"}
+    
+        if instances:
+            instance_identifier = instances[0].get("identifier")
+            if not instance_identifier:
+                return {"Status": "Failed", "Message": "Instance found but identifier is missing."}
+    
+            script_params = {}
+            script_params["Remote Server"] = remote_server
+            script_params["Remote Username"] = remote_username
+            script_params["Remote Password"] = remote_password
+            if remote_port is not None:
+                script_params["Remote Port"] = remote_port
+            script_params["Logoff Username"] = logoff_username
+    
+            # Prepare data model for the API request
+            action_data = ApiManualActionDataModel(
+                alertGroupIdentifiers=alert_group_identifiers,
+                caseId=case_id,
+                targetEntities=final_target_entities,
+                scope=final_scope,
+                isPredefinedScope=is_predefined_scope,
+                actionProvider="Scripts",
+                actionName="SSH_Logoff User",
+                properties={
+                    "IntegrationInstance": instance_identifier,
+                    "ScriptName": "SSH_Logoff User",
+                    "ScriptParametersEntityFields": json.dumps(script_params)
+                }
+            )
+    
+            try:
+                execution_response = await bindings.http_client.post(
+                    Endpoints.EXECUTE_MANUAL_ACTION,
+                    req=action_data.model_dump()
+                )
+                return execution_response
+            except Exception as e:
+                print(f"Error executing action SSH_Logoff User for SSH: {e}")
+                return {"Status": "Failed", "Message": f"Error executing action: {e}"}
+        else:
+            print(f"Warning: No active integration instance found for SSH")
+            return {"Status": "Failed", "Message": "No active instance found."}
+
+    @mcp.tool()
+    async def ssh_ping(case_id: Annotated[str, Field(..., description="The ID of the case.")], alert_group_identifiers: Annotated[List[str], Field(..., description="Identifiers for the alert groups.")], target_entities: Annotated[List[TargetEntity], Field(default_factory=list, description="Optional list of specific target entities (Identifier, EntityType) to run the action on.")], scope: Annotated[str, Field(default="All entities", description="Defines the scope for the action.")]) -> dict:
+        """Test Connectivity
+
+        Returns:
+            dict: A dictionary containing the result of the action execution.
+        """
+        final_target_entities: Optional[List[TargetEntity]] = None
+        final_scope: Optional[str] = None
+        is_predefined_scope: Optional[bool] = None
+    
+        if target_entities:
+            # Specific target entities provided, ignore scope parameter
+            final_target_entities = target_entities
+            final_scope = None
+            is_predefined_scope = False
+        else:
+            # Check if the provided scope is valid
+            if scope not in bindings.valid_scopes:
+                allowed_values_str = ", ".join(sorted(list(bindings.valid_scopes)))
+                return {
+                    "Status": "Failed",
+                    "Message": f"Invalid scope '{scope}'. Allowed values are: {allowed_values_str}",
+                }
+            final_target_entities = [] # Pass empty list for entities when using scope
+            final_scope = scope
+            is_predefined_scope = True
+    
+        # Fetch integration instance identifier
+        try:
+            instance_response = await bindings.http_client.get(
+                Endpoints.LIST_INTEGRATION_INSTANCES.format(INTEGRATION_NAME="SSH")
+            )
+            instances = instance_response.get("integration_instances", [])
+        except Exception as e:
+            print(f"Error fetching instance for SSH: {e}")
+            return {"Status": "Failed", "Message": f"Error fetching instance: {e}"}
+    
+        if instances:
+            instance_identifier = instances[0].get("identifier")
+            if not instance_identifier:
+                return {"Status": "Failed", "Message": "Instance found but identifier is missing."}
+    
+            script_params = {}
+    
+            # Prepare data model for the API request
+            action_data = ApiManualActionDataModel(
+                alertGroupIdentifiers=alert_group_identifiers,
+                caseId=case_id,
+                targetEntities=final_target_entities,
+                scope=final_scope,
+                isPredefinedScope=is_predefined_scope,
+                actionProvider="Scripts",
+                actionName="SSH_Ping",
+                properties={
+                    "IntegrationInstance": instance_identifier,
+                    "ScriptName": "SSH_Ping",
+                    "ScriptParametersEntityFields": json.dumps(script_params)
+                }
+            )
+    
+            try:
+                execution_response = await bindings.http_client.post(
+                    Endpoints.EXECUTE_MANUAL_ACTION,
+                    req=action_data.model_dump()
+                )
+                return execution_response
+            except Exception as e:
+                print(f"Error executing action SSH_Ping for SSH: {e}")
+                return {"Status": "Failed", "Message": f"Error executing action: {e}"}
+        else:
+            print(f"Warning: No active integration instance found for SSH")
+            return {"Status": "Failed", "Message": "No active instance found."}
+
+    @mcp.tool()
+    async def ssh_execute_program(case_id: Annotated[str, Field(..., description="The ID of the case.")], alert_group_identifiers: Annotated[List[str], Field(..., description="Identifiers for the alert groups.")], remote_server: Annotated[str, Field(..., description="Remote server address(e.g: x.x.x.x).")], remote_username: Annotated[str, Field(..., description="")], remote_password: Annotated[str, Field(..., description="")], remote_program_path: Annotated[str, Field(..., description="The path to the program in the remote host.")], remote_port: Annotated[str, Field(default=None, description="")], target_entities: Annotated[List[TargetEntity], Field(default_factory=list, description="Optional list of specific target entities (Identifier, EntityType) to run the action on.")], scope: Annotated[str, Field(default="All entities", description="Defines the scope for the action.")]) -> dict:
+        """
+Run script on a remote machine
+
+Action Parameters: Remote Server: Remote server address (example: x.x.x.x)., Remote Username: , Remote Password: , Remote Port: , Remote Program Path: The path to the program in the remote host.
+
+Returns:
+dict: A dictionary containing the result of the action execution.
+"""
+        final_target_entities: Optional[List[TargetEntity]] = None
+        final_scope: Optional[str] = None
+        is_predefined_scope: Optional[bool] = None
+    
+        if target_entities:
+            # Specific target entities provided, ignore scope parameter
+            final_target_entities = target_entities
+            final_scope = None
+            is_predefined_scope = False
+        else:
+            # Check if the provided scope is valid
+            if scope not in bindings.valid_scopes:
+                allowed_values_str = ", ".join(sorted(list(bindings.valid_scopes)))
+                return {
+                    "Status": "Failed",
+                    "Message": f"Invalid scope '{scope}'. Allowed values are: {allowed_values_str}",
+                }
+            final_target_entities = [] # Pass empty list for entities when using scope
+            final_scope = scope
+            is_predefined_scope = True
+    
+        # Fetch integration instance identifier
+        try:
+            instance_response = await bindings.http_client.get(
+                Endpoints.LIST_INTEGRATION_INSTANCES.format(INTEGRATION_NAME="SSH")
+            )
+            instances = instance_response.get("integration_instances", [])
+        except Exception as e:
+            print(f"Error fetching instance for SSH: {e}")
+            return {"Status": "Failed", "Message": f"Error fetching instance: {e}"}
+    
+        if instances:
+            instance_identifier = instances[0].get("identifier")
+            if not instance_identifier:
+                return {"Status": "Failed", "Message": "Instance found but identifier is missing."}
+    
+            script_params = {}
+            script_params["Remote Server"] = remote_server
+            script_params["Remote Username"] = remote_username
+            script_params["Remote Password"] = remote_password
+            if remote_port is not None:
+                script_params["Remote Port"] = remote_port
+            script_params["Remote Program Path"] = remote_program_path
+    
+            # Prepare data model for the API request
+            action_data = ApiManualActionDataModel(
+                alertGroupIdentifiers=alert_group_identifiers,
+                caseId=case_id,
+                targetEntities=final_target_entities,
+                scope=final_scope,
+                isPredefinedScope=is_predefined_scope,
+                actionProvider="Scripts",
+                actionName="SSH_Execute Program",
+                properties={
+                    "IntegrationInstance": instance_identifier,
+                    "ScriptName": "SSH_Execute Program",
+                    "ScriptParametersEntityFields": json.dumps(script_params)
+                }
+            )
+    
+            try:
+                execution_response = await bindings.http_client.post(
+                    Endpoints.EXECUTE_MANUAL_ACTION,
+                    req=action_data.model_dump()
+                )
+                return execution_response
+            except Exception as e:
+                print(f"Error executing action SSH_Execute Program for SSH: {e}")
+                return {"Status": "Failed", "Message": f"Error executing action: {e}"}
+        else:
+            print(f"Warning: No active integration instance found for SSH")
+            return {"Status": "Failed", "Message": "No active instance found."}
+
+    @mcp.tool()
+    async def ssh_list_processes(case_id: Annotated[str, Field(..., description="The ID of the case.")], alert_group_identifiers: Annotated[List[str], Field(..., description="Identifiers for the alert groups.")], remote_server: Annotated[str, Field(..., description="Remote server address(e.g: x.x.x.x).")], remote_username: Annotated[str, Field(..., description="")], remote_password: Annotated[str, Field(..., description="")], remote_port: Annotated[str, Field(default=None, description="The default port will be 22.")], target_entities: Annotated[List[TargetEntity], Field(default_factory=list, description="Optional list of specific target entities (Identifier, EntityType) to run the action on.")], scope: Annotated[str, Field(default="All entities", description="Defines the scope for the action.")]) -> dict:
+        """
+List running processes on a remote machine
+
+Action Parameters: Remote Server: Remote server address (example: x.x.x.x)., Remote Username: , Remote Password: , Remote Port: The default port will be 22.
+
+Returns:
+dict: A dictionary containing the result of the action execution.
+"""
+        final_target_entities: Optional[List[TargetEntity]] = None
+        final_scope: Optional[str] = None
+        is_predefined_scope: Optional[bool] = None
+    
+        if target_entities:
+            # Specific target entities provided, ignore scope parameter
+            final_target_entities = target_entities
+            final_scope = None
+            is_predefined_scope = False
+        else:
+            # Check if the provided scope is valid
+            if scope not in bindings.valid_scopes:
+                allowed_values_str = ", ".join(sorted(list(bindings.valid_scopes)))
+                return {
+                    "Status": "Failed",
+                    "Message": f"Invalid scope '{scope}'. Allowed values are: {allowed_values_str}",
+                }
+            final_target_entities = [] # Pass empty list for entities when using scope
+            final_scope = scope
+            is_predefined_scope = True
+    
+        # Fetch integration instance identifier
+        try:
+            instance_response = await bindings.http_client.get(
+                Endpoints.LIST_INTEGRATION_INSTANCES.format(INTEGRATION_NAME="SSH")
+            )
+            instances = instance_response.get("integration_instances", [])
+        except Exception as e:
+            print(f"Error fetching instance for SSH: {e}")
+            return {"Status": "Failed", "Message": f"Error fetching instance: {e}"}
+    
+        if instances:
+            instance_identifier = instances[0].get("identifier")
+            if not instance_identifier:
+                return {"Status": "Failed", "Message": "Instance found but identifier is missing."}
+    
+            script_params = {}
+            script_params["Remote Server"] = remote_server
+            script_params["Remote Username"] = remote_username
+            script_params["Remote Password"] = remote_password
+            if remote_port is not None:
+                script_params["Remote Port"] = remote_port
+    
+            # Prepare data model for the API request
+            action_data = ApiManualActionDataModel(
+                alertGroupIdentifiers=alert_group_identifiers,
+                caseId=case_id,
+                targetEntities=final_target_entities,
+                scope=final_scope,
+                isPredefinedScope=is_predefined_scope,
+                actionProvider="Scripts",
+                actionName="SSH_List Processes",
+                properties={
+                    "IntegrationInstance": instance_identifier,
+                    "ScriptName": "SSH_List Processes",
+                    "ScriptParametersEntityFields": json.dumps(script_params)
+                }
+            )
+    
+            try:
+                execution_response = await bindings.http_client.post(
+                    Endpoints.EXECUTE_MANUAL_ACTION,
+                    req=action_data.model_dump()
+                )
+                return execution_response
+            except Exception as e:
+                print(f"Error executing action SSH_List Processes for SSH: {e}")
+                return {"Status": "Failed", "Message": f"Error executing action: {e}"}
+        else:
+            print(f"Warning: No active integration instance found for SSH")
+            return {"Status": "Failed", "Message": "No active instance found."}
+
+    @mcp.tool()
+    async def ssh_list_iptables_rules(case_id: Annotated[str, Field(..., description="The ID of the case.")], alert_group_identifiers: Annotated[List[str], Field(..., description="Identifiers for the alert groups.")], remote_server: Annotated[str, Field(..., description="Remote server address(e.g: x.x.x.x)")], remote_username: Annotated[str, Field(..., description="")], remote_password: Annotated[str, Field(..., description="")], remote_port: Annotated[str, Field(default=None, description="The default port will be 22.")], chain: Annotated[str, Field(default=None, description="The iptables chain that you wish to see (e.g: INPUT, OUTPUT, etc.)")], target_entities: Annotated[List[TargetEntity], Field(default_factory=list, description="Optional list of specific target entities (Identifier, EntityType) to run the action on.")], scope: Annotated[str, Field(default="All entities", description="Defines the scope for the action.")]) -> dict:
+        """
+List iptables rules on a remote machine
+
+Action Parameters: Remote Server: Remote server address (example: x.x.x.x)., Remote Username: , Remote Password: , Remote Port: The default port will be 22., Chain: The IPtables chain that you wish to see (example: INPUT, OUTPUT, etc.).
+
+Returns:
+dict: A dictionary containing the result of the action execution.
+"""
+        final_target_entities: Optional[List[TargetEntity]] = None
+        final_scope: Optional[str] = None
+        is_predefined_scope: Optional[bool] = None
+    
+        if target_entities:
+            # Specific target entities provided, ignore scope parameter
+            final_target_entities = target_entities
+            final_scope = None
+            is_predefined_scope = False
+        else:
+            # Check if the provided scope is valid
+            if scope not in bindings.valid_scopes:
+                allowed_values_str = ", ".join(sorted(list(bindings.valid_scopes)))
+                return {
+                    "Status": "Failed",
+                    "Message": f"Invalid scope '{scope}'. Allowed values are: {allowed_values_str}",
+                }
+            final_target_entities = [] # Pass empty list for entities when using scope
+            final_scope = scope
+            is_predefined_scope = True
+    
+        # Fetch integration instance identifier
+        try:
+            instance_response = await bindings.http_client.get(
+                Endpoints.LIST_INTEGRATION_INSTANCES.format(INTEGRATION_NAME="SSH")
+            )
+            instances = instance_response.get("integration_instances", [])
+        except Exception as e:
+            print(f"Error fetching instance for SSH: {e}")
+            return {"Status": "Failed", "Message": f"Error fetching instance: {e}"}
+    
+        if instances:
+            instance_identifier = instances[0].get("identifier")
+            if not instance_identifier:
+                return {"Status": "Failed", "Message": "Instance found but identifier is missing."}
+    
+            script_params = {}
+            script_params["Remote Server"] = remote_server
+            script_params["Remote Username"] = remote_username
+            script_params["Remote Password"] = remote_password
+            if remote_port is not None:
+                script_params["Remote Port"] = remote_port
+            if chain is not None:
+                script_params["Chain"] = chain
+    
+            # Prepare data model for the API request
+            action_data = ApiManualActionDataModel(
+                alertGroupIdentifiers=alert_group_identifiers,
+                caseId=case_id,
+                targetEntities=final_target_entities,
+                scope=final_scope,
+                isPredefinedScope=is_predefined_scope,
+                actionProvider="Scripts",
+                actionName="SSH_List iptables Rules",
+                properties={
+                    "IntegrationInstance": instance_identifier,
+                    "ScriptName": "SSH_List iptables Rules",
+                    "ScriptParametersEntityFields": json.dumps(script_params)
+                }
+            )
+    
+            try:
+                execution_response = await bindings.http_client.post(
+                    Endpoints.EXECUTE_MANUAL_ACTION,
+                    req=action_data.model_dump()
+                )
+                return execution_response
+            except Exception as e:
+                print(f"Error executing action SSH_List iptables Rules for SSH: {e}")
+                return {"Status": "Failed", "Message": f"Error executing action: {e}"}
+        else:
+            print(f"Warning: No active integration instance found for SSH")
+            return {"Status": "Failed", "Message": "No active instance found."}
+
+    @mcp.tool()
+    async def ssh_run_command(case_id: Annotated[str, Field(..., description="The ID of the case.")], alert_group_identifiers: Annotated[List[str], Field(..., description="Identifiers for the alert groups.")], remote_server: Annotated[str, Field(..., description="Remote server address(e.g: x.x.x.x).")], remote_username: Annotated[str, Field(..., description="")], remote_password: Annotated[str, Field(..., description="")], command: Annotated[str, Field(..., description="Command content(e.g: ifconfig).")], remote_port: Annotated[str, Field(default=None, description="")], target_entities: Annotated[List[TargetEntity], Field(default_factory=list, description="Optional list of specific target entities (Identifier, EntityType) to run the action on.")], scope: Annotated[str, Field(default="All entities", description="Defines the scope for the action.")]) -> dict:
+        """
+Run command on a remote machine
+
+Action Parameters: Remote Server: Remote server address (example: x.x.x.x)., Remote Username: , Remote Password: , Remote Port: , Command: Command content (example: ifconfig).
+
+Returns:
+dict: A dictionary containing the result of the action execution.
+"""
+        final_target_entities: Optional[List[TargetEntity]] = None
+        final_scope: Optional[str] = None
+        is_predefined_scope: Optional[bool] = None
+    
+        if target_entities:
+            # Specific target entities provided, ignore scope parameter
+            final_target_entities = target_entities
+            final_scope = None
+            is_predefined_scope = False
+        else:
+            # Check if the provided scope is valid
+            if scope not in bindings.valid_scopes:
+                allowed_values_str = ", ".join(sorted(list(bindings.valid_scopes)))
+                return {
+                    "Status": "Failed",
+                    "Message": f"Invalid scope '{scope}'. Allowed values are: {allowed_values_str}",
+                }
+            final_target_entities = [] # Pass empty list for entities when using scope
+            final_scope = scope
+            is_predefined_scope = True
+    
+        # Fetch integration instance identifier
+        try:
+            instance_response = await bindings.http_client.get(
+                Endpoints.LIST_INTEGRATION_INSTANCES.format(INTEGRATION_NAME="SSH")
+            )
+            instances = instance_response.get("integration_instances", [])
+        except Exception as e:
+            print(f"Error fetching instance for SSH: {e}")
+            return {"Status": "Failed", "Message": f"Error fetching instance: {e}"}
+    
+        if instances:
+            instance_identifier = instances[0].get("identifier")
+            if not instance_identifier:
+                return {"Status": "Failed", "Message": "Instance found but identifier is missing."}
+    
+            script_params = {}
+            script_params["Remote Server"] = remote_server
+            script_params["Remote Username"] = remote_username
+            script_params["Remote Password"] = remote_password
+            if remote_port is not None:
+                script_params["Remote Port"] = remote_port
+            script_params["Command"] = command
+    
+            # Prepare data model for the API request
+            action_data = ApiManualActionDataModel(
+                alertGroupIdentifiers=alert_group_identifiers,
+                caseId=case_id,
+                targetEntities=final_target_entities,
+                scope=final_scope,
+                isPredefinedScope=is_predefined_scope,
+                actionProvider="Scripts",
+                actionName="SSH_Run Command",
+                properties={
+                    "IntegrationInstance": instance_identifier,
+                    "ScriptName": "SSH_Run Command",
+                    "ScriptParametersEntityFields": json.dumps(script_params)
+                }
+            )
+    
+            try:
+                execution_response = await bindings.http_client.post(
+                    Endpoints.EXECUTE_MANUAL_ACTION,
+                    req=action_data.model_dump()
+                )
+                return execution_response
+            except Exception as e:
+                print(f"Error executing action SSH_Run Command for SSH: {e}")
+                return {"Status": "Failed", "Message": f"Error executing action: {e}"}
+        else:
+            print(f"Warning: No active integration instance found for SSH")
+            return {"Status": "Failed", "Message": "No active instance found."}
+
+    @mcp.tool()
+    async def ssh_list_connections(case_id: Annotated[str, Field(..., description="The ID of the case.")], alert_group_identifiers: Annotated[List[str], Field(..., description="Identifiers for the alert groups.")], remote_server: Annotated[str, Field(..., description="Remote server address(e.g: x.x.x.x).")], remote_username: Annotated[str, Field(..., description="")], remote_password: Annotated[str, Field(..., description="")], remote_port: Annotated[str, Field(default=None, description="")], target_entities: Annotated[List[TargetEntity], Field(default_factory=list, description="Optional list of specific target entities (Identifier, EntityType) to run the action on.")], scope: Annotated[str, Field(default="All entities", description="Defines the scope for the action.")]) -> dict:
+        """
+List all  connections on a remote machine
+
+Action Parameters: Remote Server: Remote server address (example: x.x.x.x)., Remote Username: , Remote Password: , Remote Port:
+
+Returns:
+dict: A dictionary containing the result of the action execution.
+"""
+        final_target_entities: Optional[List[TargetEntity]] = None
+        final_scope: Optional[str] = None
+        is_predefined_scope: Optional[bool] = None
+    
+        if target_entities:
+            # Specific target entities provided, ignore scope parameter
+            final_target_entities = target_entities
+            final_scope = None
+            is_predefined_scope = False
+        else:
+            # Check if the provided scope is valid
+            if scope not in bindings.valid_scopes:
+                allowed_values_str = ", ".join(sorted(list(bindings.valid_scopes)))
+                return {
+                    "Status": "Failed",
+                    "Message": f"Invalid scope '{scope}'. Allowed values are: {allowed_values_str}",
+                }
+            final_target_entities = [] # Pass empty list for entities when using scope
+            final_scope = scope
+            is_predefined_scope = True
+    
+        # Fetch integration instance identifier
+        try:
+            instance_response = await bindings.http_client.get(
+                Endpoints.LIST_INTEGRATION_INSTANCES.format(INTEGRATION_NAME="SSH")
+            )
+            instances = instance_response.get("integration_instances", [])
+        except Exception as e:
+            print(f"Error fetching instance for SSH: {e}")
+            return {"Status": "Failed", "Message": f"Error fetching instance: {e}"}
+    
+        if instances:
+            instance_identifier = instances[0].get("identifier")
+            if not instance_identifier:
+                return {"Status": "Failed", "Message": "Instance found but identifier is missing."}
+    
+            script_params = {}
+            script_params["Remote Server"] = remote_server
+            script_params["Remote Username"] = remote_username
+            script_params["Remote Password"] = remote_password
+            if remote_port is not None:
+                script_params["Remote Port"] = remote_port
+    
+            # Prepare data model for the API request
+            action_data = ApiManualActionDataModel(
+                alertGroupIdentifiers=alert_group_identifiers,
+                caseId=case_id,
+                targetEntities=final_target_entities,
+                scope=final_scope,
+                isPredefinedScope=is_predefined_scope,
+                actionProvider="Scripts",
+                actionName="SSH_List Connections",
+                properties={
+                    "IntegrationInstance": instance_identifier,
+                    "ScriptName": "SSH_List Connections",
+                    "ScriptParametersEntityFields": json.dumps(script_params)
+                }
+            )
+    
+            try:
+                execution_response = await bindings.http_client.post(
+                    Endpoints.EXECUTE_MANUAL_ACTION,
+                    req=action_data.model_dump()
+                )
+                return execution_response
+            except Exception as e:
+                print(f"Error executing action SSH_List Connections for SSH: {e}")
+                return {"Status": "Failed", "Message": f"Error executing action: {e}"}
+        else:
+            print(f"Warning: No active integration instance found for SSH")
+            return {"Status": "Failed", "Message": "No active instance found."}
+
+    @mcp.tool()
+    async def ssh_block_ip_address_in_iptables(case_id: Annotated[str, Field(..., description="The ID of the case.")], alert_group_identifiers: Annotated[List[str], Field(..., description="Identifiers for the alert groups.")], remote_server: Annotated[str, Field(..., description="Remote server address(e.g: x.x.x.x).")], remote_username: Annotated[str, Field(..., description="")], remote_password: Annotated[str, Field(..., description="")], block_ip_address: Annotated[str, Field(..., description="IP address to block(e.g: x.x.x.x).")], remote_port: Annotated[str, Field(default=None, description="")], target_entities: Annotated[List[TargetEntity], Field(default_factory=list, description="Optional list of specific target entities (Identifier, EntityType) to run the action on.")], scope: Annotated[str, Field(default="All entities", description="Defines the scope for the action.")]) -> dict:
+        """
+Add rule to iptables to block IP address
+
+Action Parameters: Remote Server: Remote server address., Remote Username: , Remote Password: , Remote Port: , Block IP Address: IP address to block.
+
+Returns:
+dict: A dictionary containing the result of the action execution.
+"""
+        final_target_entities: Optional[List[TargetEntity]] = None
+        final_scope: Optional[str] = None
+        is_predefined_scope: Optional[bool] = None
+    
+        if target_entities:
+            # Specific target entities provided, ignore scope parameter
+            final_target_entities = target_entities
+            final_scope = None
+            is_predefined_scope = False
+        else:
+            # Check if the provided scope is valid
+            if scope not in bindings.valid_scopes:
+                allowed_values_str = ", ".join(sorted(list(bindings.valid_scopes)))
+                return {
+                    "Status": "Failed",
+                    "Message": f"Invalid scope '{scope}'. Allowed values are: {allowed_values_str}",
+                }
+            final_target_entities = [] # Pass empty list for entities when using scope
+            final_scope = scope
+            is_predefined_scope = True
+    
+        # Fetch integration instance identifier
+        try:
+            instance_response = await bindings.http_client.get(
+                Endpoints.LIST_INTEGRATION_INSTANCES.format(INTEGRATION_NAME="SSH")
+            )
+            instances = instance_response.get("integration_instances", [])
+        except Exception as e:
+            print(f"Error fetching instance for SSH: {e}")
+            return {"Status": "Failed", "Message": f"Error fetching instance: {e}"}
+    
+        if instances:
+            instance_identifier = instances[0].get("identifier")
+            if not instance_identifier:
+                return {"Status": "Failed", "Message": "Instance found but identifier is missing."}
+    
+            script_params = {}
+            script_params["Remote Server"] = remote_server
+            script_params["Remote Username"] = remote_username
+            script_params["Remote Password"] = remote_password
+            if remote_port is not None:
+                script_params["Remote Port"] = remote_port
+            script_params["Block IP Address"] = block_ip_address
+    
+            # Prepare data model for the API request
+            action_data = ApiManualActionDataModel(
+                alertGroupIdentifiers=alert_group_identifiers,
+                caseId=case_id,
+                targetEntities=final_target_entities,
+                scope=final_scope,
+                isPredefinedScope=is_predefined_scope,
+                actionProvider="Scripts",
+                actionName="SSH_Block IP Address in iptables",
+                properties={
+                    "IntegrationInstance": instance_identifier,
+                    "ScriptName": "SSH_Block IP Address in iptables",
+                    "ScriptParametersEntityFields": json.dumps(script_params)
+                }
+            )
+    
+            try:
+                execution_response = await bindings.http_client.post(
+                    Endpoints.EXECUTE_MANUAL_ACTION,
+                    req=action_data.model_dump()
+                )
+                return execution_response
+            except Exception as e:
+                print(f"Error executing action SSH_Block IP Address in iptables for SSH: {e}")
+                return {"Status": "Failed", "Message": f"Error executing action: {e}"}
+        else:
+            print(f"Warning: No active integration instance found for SSH")
+            return {"Status": "Failed", "Message": "No active instance found."}
+
+    @mcp.tool()
+    async def ssh_shutdown_machine(case_id: Annotated[str, Field(..., description="The ID of the case.")], alert_group_identifiers: Annotated[List[str], Field(..., description="Identifiers for the alert groups.")], remote_server: Annotated[str, Field(..., description="Remote server address(e.g: x.x.x.x)")], remote_username: Annotated[str, Field(..., description="")], remote_password: Annotated[str, Field(..., description="")], wait_time: Annotated[str, Field(..., description="Time to wait before shutdown in minutes(e.g: now).")], remote_port: Annotated[str, Field(default=None, description="The default port will be 22.")], target_entities: Annotated[List[TargetEntity], Field(default_factory=list, description="Optional list of specific target entities (Identifier, EntityType) to run the action on.")], scope: Annotated[str, Field(default="All entities", description="Defines the scope for the action.")]) -> dict:
+        """
+Shutdown remote machine
+
+Action Parameters: Remote Server: Remote server address (example: x.x.x.x)., Remote Username: , Remote Password: , Remote Port: The default port will be 22., Wait Time: Time to wait before shutdown in minutes (example: now).
+
+Returns:
+dict: A dictionary containing the result of the action execution.
+"""
+        final_target_entities: Optional[List[TargetEntity]] = None
+        final_scope: Optional[str] = None
+        is_predefined_scope: Optional[bool] = None
+    
+        if target_entities:
+            # Specific target entities provided, ignore scope parameter
+            final_target_entities = target_entities
+            final_scope = None
+            is_predefined_scope = False
+        else:
+            # Check if the provided scope is valid
+            if scope not in bindings.valid_scopes:
+                allowed_values_str = ", ".join(sorted(list(bindings.valid_scopes)))
+                return {
+                    "Status": "Failed",
+                    "Message": f"Invalid scope '{scope}'. Allowed values are: {allowed_values_str}",
+                }
+            final_target_entities = [] # Pass empty list for entities when using scope
+            final_scope = scope
+            is_predefined_scope = True
+    
+        # Fetch integration instance identifier
+        try:
+            instance_response = await bindings.http_client.get(
+                Endpoints.LIST_INTEGRATION_INSTANCES.format(INTEGRATION_NAME="SSH")
+            )
+            instances = instance_response.get("integration_instances", [])
+        except Exception as e:
+            print(f"Error fetching instance for SSH: {e}")
+            return {"Status": "Failed", "Message": f"Error fetching instance: {e}"}
+    
+        if instances:
+            instance_identifier = instances[0].get("identifier")
+            if not instance_identifier:
+                return {"Status": "Failed", "Message": "Instance found but identifier is missing."}
+    
+            script_params = {}
+            script_params["Remote Server"] = remote_server
+            script_params["Remote Username"] = remote_username
+            script_params["Remote Password"] = remote_password
+            if remote_port is not None:
+                script_params["Remote Port"] = remote_port
+            script_params["Wait Time"] = wait_time
+    
+            # Prepare data model for the API request
+            action_data = ApiManualActionDataModel(
+                alertGroupIdentifiers=alert_group_identifiers,
+                caseId=case_id,
+                targetEntities=final_target_entities,
+                scope=final_scope,
+                isPredefinedScope=is_predefined_scope,
+                actionProvider="Scripts",
+                actionName="SSH_Shutdown Machine",
+                properties={
+                    "IntegrationInstance": instance_identifier,
+                    "ScriptName": "SSH_Shutdown Machine",
+                    "ScriptParametersEntityFields": json.dumps(script_params)
+                }
+            )
+    
+            try:
+                execution_response = await bindings.http_client.post(
+                    Endpoints.EXECUTE_MANUAL_ACTION,
+                    req=action_data.model_dump()
+                )
+                return execution_response
+            except Exception as e:
+                print(f"Error executing action SSH_Shutdown Machine for SSH: {e}")
+                return {"Status": "Failed", "Message": f"Error executing action: {e}"}
+        else:
+            print(f"Warning: No active integration instance found for SSH")
+            return {"Status": "Failed", "Message": "No active instance found."}
+
+    @mcp.tool()
+    async def ssh_delete_firewall_rule(case_id: Annotated[str, Field(..., description="The ID of the case.")], alert_group_identifiers: Annotated[List[str], Field(..., description="Identifiers for the alert groups.")], remote_server: Annotated[str, Field(..., description="Remote server address(e.g: x.x.x.x).")], remote_username: Annotated[str, Field(..., description="")], remote_password: Annotated[str, Field(..., description="")], i_ptables_rule: Annotated[str, Field(..., description="Rule value(e.g: INPUT -s 10.0.0.10 -j DROP)")], remote_port: Annotated[str, Field(default=None, description="")], target_entities: Annotated[List[TargetEntity], Field(default_factory=list, description="Optional list of specific target entities (Identifier, EntityType) to run the action on.")], scope: Annotated[str, Field(default="All entities", description="Defines the scope for the action.")]) -> dict:
+        """
+Delete iptables Firewall rule (Example: INPUT -s 10.0.0.10 -j DROP)
+
+Action Parameters: Remote Server: , Remote Username: , Remote Password: , Remote Port: , IPtables Rule: Rule value (example: INPUT -s 10.0.0.10 -j DROP).
+
+Returns:
+dict: A dictionary containing the result of the action execution.
+"""
+        final_target_entities: Optional[List[TargetEntity]] = None
+        final_scope: Optional[str] = None
+        is_predefined_scope: Optional[bool] = None
+    
+        if target_entities:
+            # Specific target entities provided, ignore scope parameter
+            final_target_entities = target_entities
+            final_scope = None
+            is_predefined_scope = False
+        else:
+            # Check if the provided scope is valid
+            if scope not in bindings.valid_scopes:
+                allowed_values_str = ", ".join(sorted(list(bindings.valid_scopes)))
+                return {
+                    "Status": "Failed",
+                    "Message": f"Invalid scope '{scope}'. Allowed values are: {allowed_values_str}",
+                }
+            final_target_entities = [] # Pass empty list for entities when using scope
+            final_scope = scope
+            is_predefined_scope = True
+    
+        # Fetch integration instance identifier
+        try:
+            instance_response = await bindings.http_client.get(
+                Endpoints.LIST_INTEGRATION_INSTANCES.format(INTEGRATION_NAME="SSH")
+            )
+            instances = instance_response.get("integration_instances", [])
+        except Exception as e:
+            print(f"Error fetching instance for SSH: {e}")
+            return {"Status": "Failed", "Message": f"Error fetching instance: {e}"}
+    
+        if instances:
+            instance_identifier = instances[0].get("identifier")
+            if not instance_identifier:
+                return {"Status": "Failed", "Message": "Instance found but identifier is missing."}
+    
+            script_params = {}
+            script_params["Remote Server"] = remote_server
+            script_params["Remote Username"] = remote_username
+            script_params["Remote Password"] = remote_password
+            if remote_port is not None:
+                script_params["Remote Port"] = remote_port
+            script_params["IPtables Rule"] = i_ptables_rule
+    
+            # Prepare data model for the API request
+            action_data = ApiManualActionDataModel(
+                alertGroupIdentifiers=alert_group_identifiers,
+                caseId=case_id,
+                targetEntities=final_target_entities,
+                scope=final_scope,
+                isPredefinedScope=is_predefined_scope,
+                actionProvider="Scripts",
+                actionName="SSH_Delete Firewall Rule",
+                properties={
+                    "IntegrationInstance": instance_identifier,
+                    "ScriptName": "SSH_Delete Firewall Rule",
+                    "ScriptParametersEntityFields": json.dumps(script_params)
+                }
+            )
+    
+            try:
+                execution_response = await bindings.http_client.post(
+                    Endpoints.EXECUTE_MANUAL_ACTION,
+                    req=action_data.model_dump()
+                )
+                return execution_response
+            except Exception as e:
+                print(f"Error executing action SSH_Delete Firewall Rule for SSH: {e}")
+                return {"Status": "Failed", "Message": f"Error executing action: {e}"}
+        else:
+            print(f"Warning: No active integration instance found for SSH")
+            return {"Status": "Failed", "Message": "No active instance found."}

--- a/mcp_marketplace/zendesk.py
+++ b/mcp_marketplace/zendesk.py
@@ -1,0 +1,600 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from secops_soar_mcp import bindings
+from mcp.server.fastmcp import FastMCP
+from secops_soar_mcp.utils.consts import Endpoints
+from secops_soar_mcp.utils.models import ApiManualActionDataModel, EmailContent, TargetEntity
+import json
+from typing import Optional, Any, List, Dict, Union, Annotated
+from pydantic import Field
+
+
+def register_tools(mcp: FastMCP):
+    # This function registers all tools (actions) for the Zendesk integration.
+
+    @mcp.tool()
+    async def zendesk_create_ticket(case_id: Annotated[str, Field(..., description="The ID of the case.")], alert_group_identifiers: Annotated[List[str], Field(..., description="Identifiers for the alert groups.")], subject: Annotated[str, Field(..., description="")], description: Annotated[str, Field(..., description="")], assigned_user: Annotated[str, Field(default=None, description="User full name.")], assignment_group: Annotated[str, Field(default=None, description="Group name.")], priority: Annotated[str, Field(default=None, description="Priority will be one of the following: urgent, high, normal or low.")], ticket_type: Annotated[str, Field(default=None, description="The ticket type will be one of the following: problem, incident, question or task.")], tag: Annotated[str, Field(default=None, description="")], internal_note: Annotated[bool, Field(default=None, description="Specify whether the comment should be public, or internal. Unchecked means it will be public, checked means it will be internal only.")], email_c_cs: Annotated[str, Field(default=None, description="Specify a comma-separated list of email addresses, which should also receive the notification of the ticket creation. Note: at max 48 email CCs can be added. This is Zendesk limitation.")], validate_email_c_cs: Annotated[bool, Field(default=None, description="If enabled, action will try to check that users with emails provided in \u201cEmail CCs\u201c parameter exist. If at least one user doesn\u2019t exist, action will fail. If this parameter is disabled, action will not perform this check.")], target_entities: Annotated[List[TargetEntity], Field(default_factory=list, description="Optional list of specific target entities (Identifier, EntityType) to run the action on.")], scope: Annotated[str, Field(default="All entities", description="Defines the scope for the action.")]) -> dict:
+        """
+Create a ticket with specific properties
+
+Action Parameters: Subject: , Description: , Assigned User: User full name., Assignment Group: Group name., Priority: Priority will be one of the following: urgent, high, normal, or low., Ticket Type: Priority will be one of the following: urgent, high, normal, or low., Tag: , Internal Note: Specify whether the comment should be public, or internal. Unchecked means it will be public, checked means it will be internal only, Email CCs: Specify a comma-separated list of email addresses, which should also receive the notification of the ticket creation. Note: at max 48 email CCs can be added. This is Zendesk limitation., Validate Email CCs: If enabled, action will try to check that users with emails provided in "Email CCs" parameter exist. If at least one user doesn't exist, action will fail. If this parameter is disabled, action will not perform this check.
+
+Returns:
+dict: A dictionary containing the result of the action execution.
+"""
+        final_target_entities: Optional[List[TargetEntity]] = None
+        final_scope: Optional[str] = None
+        is_predefined_scope: Optional[bool] = None
+    
+        if target_entities:
+            # Specific target entities provided, ignore scope parameter
+            final_target_entities = target_entities
+            final_scope = None
+            is_predefined_scope = False
+        else:
+            # Check if the provided scope is valid
+            if scope not in bindings.valid_scopes:
+                allowed_values_str = ", ".join(sorted(list(bindings.valid_scopes)))
+                return {
+                    "Status": "Failed",
+                    "Message": f"Invalid scope '{scope}'. Allowed values are: {allowed_values_str}",
+                }
+            final_target_entities = [] # Pass empty list for entities when using scope
+            final_scope = scope
+            is_predefined_scope = True
+    
+        # Fetch integration instance identifier
+        try:
+            instance_response = await bindings.http_client.get(
+                Endpoints.LIST_INTEGRATION_INSTANCES.format(INTEGRATION_NAME="Zendesk")
+            )
+            instances = instance_response.get("integration_instances", [])
+        except Exception as e:
+            print(f"Error fetching instance for Zendesk: {e}")
+            return {"Status": "Failed", "Message": f"Error fetching instance: {e}"}
+    
+        if instances:
+            instance_identifier = instances[0].get("identifier")
+            if not instance_identifier:
+                return {"Status": "Failed", "Message": "Instance found but identifier is missing."}
+    
+            script_params = {}
+            script_params["Subject"] = subject
+            script_params["Description"] = description
+            if assigned_user is not None:
+                script_params["Assigned User"] = assigned_user
+            if assignment_group is not None:
+                script_params["Assignment Group"] = assignment_group
+            if priority is not None:
+                script_params["Priority"] = priority
+            if ticket_type is not None:
+                script_params["Ticket Type"] = ticket_type
+            if tag is not None:
+                script_params["Tag"] = tag
+            if internal_note is not None:
+                script_params["Internal Note"] = internal_note
+            if email_c_cs is not None:
+                script_params["Email CCs"] = email_c_cs
+            if validate_email_c_cs is not None:
+                script_params["Validate Email CCs"] = validate_email_c_cs
+    
+            # Prepare data model for the API request
+            action_data = ApiManualActionDataModel(
+                alertGroupIdentifiers=alert_group_identifiers,
+                caseId=case_id,
+                targetEntities=final_target_entities,
+                scope=final_scope,
+                isPredefinedScope=is_predefined_scope,
+                actionProvider="Scripts",
+                actionName="Zendesk_Create Ticket",
+                properties={
+                    "IntegrationInstance": instance_identifier,
+                    "ScriptName": "Zendesk_Create Ticket",
+                    "ScriptParametersEntityFields": json.dumps(script_params)
+                }
+            )
+    
+            try:
+                execution_response = await bindings.http_client.post(
+                    Endpoints.EXECUTE_MANUAL_ACTION,
+                    req=action_data.model_dump()
+                )
+                return execution_response
+            except Exception as e:
+                print(f"Error executing action Zendesk_Create Ticket for Zendesk: {e}")
+                return {"Status": "Failed", "Message": f"Error executing action: {e}"}
+        else:
+            print(f"Warning: No active integration instance found for Zendesk")
+            return {"Status": "Failed", "Message": "No active instance found."}
+
+    @mcp.tool()
+    async def zendesk_get_ticket_details(case_id: Annotated[str, Field(..., description="The ID of the case.")], alert_group_identifiers: Annotated[List[str], Field(..., description="Identifiers for the alert groups.")], ticket_id: Annotated[str, Field(..., description="The ID f the ticket.")], target_entities: Annotated[List[TargetEntity], Field(default_factory=list, description="Optional list of specific target entities (Identifier, EntityType) to run the action on.")], scope: Annotated[str, Field(default="All entities", description="Defines the scope for the action.")]) -> dict:
+        """
+Get ticket details, comments, and attachments by ticket id
+
+Action Parameters: Ticket ID: The ID of the ticket.
+
+Returns:
+dict: A dictionary containing the result of the action execution.
+"""
+        final_target_entities: Optional[List[TargetEntity]] = None
+        final_scope: Optional[str] = None
+        is_predefined_scope: Optional[bool] = None
+    
+        if target_entities:
+            # Specific target entities provided, ignore scope parameter
+            final_target_entities = target_entities
+            final_scope = None
+            is_predefined_scope = False
+        else:
+            # Check if the provided scope is valid
+            if scope not in bindings.valid_scopes:
+                allowed_values_str = ", ".join(sorted(list(bindings.valid_scopes)))
+                return {
+                    "Status": "Failed",
+                    "Message": f"Invalid scope '{scope}'. Allowed values are: {allowed_values_str}",
+                }
+            final_target_entities = [] # Pass empty list for entities when using scope
+            final_scope = scope
+            is_predefined_scope = True
+    
+        # Fetch integration instance identifier
+        try:
+            instance_response = await bindings.http_client.get(
+                Endpoints.LIST_INTEGRATION_INSTANCES.format(INTEGRATION_NAME="Zendesk")
+            )
+            instances = instance_response.get("integration_instances", [])
+        except Exception as e:
+            print(f"Error fetching instance for Zendesk: {e}")
+            return {"Status": "Failed", "Message": f"Error fetching instance: {e}"}
+    
+        if instances:
+            instance_identifier = instances[0].get("identifier")
+            if not instance_identifier:
+                return {"Status": "Failed", "Message": "Instance found but identifier is missing."}
+    
+            script_params = {}
+            script_params["Ticket ID"] = ticket_id
+    
+            # Prepare data model for the API request
+            action_data = ApiManualActionDataModel(
+                alertGroupIdentifiers=alert_group_identifiers,
+                caseId=case_id,
+                targetEntities=final_target_entities,
+                scope=final_scope,
+                isPredefinedScope=is_predefined_scope,
+                actionProvider="Scripts",
+                actionName="Zendesk_Get Ticket Details",
+                properties={
+                    "IntegrationInstance": instance_identifier,
+                    "ScriptName": "Zendesk_Get Ticket Details",
+                    "ScriptParametersEntityFields": json.dumps(script_params)
+                }
+            )
+    
+            try:
+                execution_response = await bindings.http_client.post(
+                    Endpoints.EXECUTE_MANUAL_ACTION,
+                    req=action_data.model_dump()
+                )
+                return execution_response
+            except Exception as e:
+                print(f"Error executing action Zendesk_Get Ticket Details for Zendesk: {e}")
+                return {"Status": "Failed", "Message": f"Error executing action: {e}"}
+        else:
+            print(f"Warning: No active integration instance found for Zendesk")
+            return {"Status": "Failed", "Message": "No active instance found."}
+
+    @mcp.tool()
+    async def zendesk_add_comment_to_ticket(case_id: Annotated[str, Field(..., description="The ID of the case.")], alert_group_identifiers: Annotated[List[str], Field(..., description="Identifiers for the alert groups.")], ticket_id: Annotated[str, Field(..., description="Specify the Zendesk Ticket ID for which you would like to add a comment.")], comment_body: Annotated[str, Field(..., description="Provide the text you would like to be contained in the comment body")], internal_note: Annotated[bool, Field(..., description="Specify whether the comment should be public, or internal. Unchecked means it will be public, checked means it will be internal only.")], author_name: Annotated[str, Field(default=None, description="Specify the name of the author, please make sure this name exists on Zendesk")], target_entities: Annotated[List[TargetEntity], Field(default_factory=list, description="Optional list of specific target entities (Identifier, EntityType) to run the action on.")], scope: Annotated[str, Field(default="All entities", description="Defines the scope for the action.")]) -> dict:
+        """
+Add a comment to an existing ticket
+
+Action Parameters: Ticket ID: Ticket number., Comment Body: , Author Name: , Internal Note:
+
+Returns:
+dict: A dictionary containing the result of the action execution.
+"""
+        final_target_entities: Optional[List[TargetEntity]] = None
+        final_scope: Optional[str] = None
+        is_predefined_scope: Optional[bool] = None
+    
+        if target_entities:
+            # Specific target entities provided, ignore scope parameter
+            final_target_entities = target_entities
+            final_scope = None
+            is_predefined_scope = False
+        else:
+            # Check if the provided scope is valid
+            if scope not in bindings.valid_scopes:
+                allowed_values_str = ", ".join(sorted(list(bindings.valid_scopes)))
+                return {
+                    "Status": "Failed",
+                    "Message": f"Invalid scope '{scope}'. Allowed values are: {allowed_values_str}",
+                }
+            final_target_entities = [] # Pass empty list for entities when using scope
+            final_scope = scope
+            is_predefined_scope = True
+    
+        # Fetch integration instance identifier
+        try:
+            instance_response = await bindings.http_client.get(
+                Endpoints.LIST_INTEGRATION_INSTANCES.format(INTEGRATION_NAME="Zendesk")
+            )
+            instances = instance_response.get("integration_instances", [])
+        except Exception as e:
+            print(f"Error fetching instance for Zendesk: {e}")
+            return {"Status": "Failed", "Message": f"Error fetching instance: {e}"}
+    
+        if instances:
+            instance_identifier = instances[0].get("identifier")
+            if not instance_identifier:
+                return {"Status": "Failed", "Message": "Instance found but identifier is missing."}
+    
+            script_params = {}
+            script_params["Ticket ID"] = ticket_id
+            script_params["Comment Body"] = comment_body
+            if author_name is not None:
+                script_params["Author Name"] = author_name
+            script_params["Internal Note"] = internal_note
+    
+            # Prepare data model for the API request
+            action_data = ApiManualActionDataModel(
+                alertGroupIdentifiers=alert_group_identifiers,
+                caseId=case_id,
+                targetEntities=final_target_entities,
+                scope=final_scope,
+                isPredefinedScope=is_predefined_scope,
+                actionProvider="Scripts",
+                actionName="Zendesk_Add Comment To Ticket",
+                properties={
+                    "IntegrationInstance": instance_identifier,
+                    "ScriptName": "Zendesk_Add Comment To Ticket",
+                    "ScriptParametersEntityFields": json.dumps(script_params)
+                }
+            )
+    
+            try:
+                execution_response = await bindings.http_client.post(
+                    Endpoints.EXECUTE_MANUAL_ACTION,
+                    req=action_data.model_dump()
+                )
+                return execution_response
+            except Exception as e:
+                print(f"Error executing action Zendesk_Add Comment To Ticket for Zendesk: {e}")
+                return {"Status": "Failed", "Message": f"Error executing action: {e}"}
+        else:
+            print(f"Warning: No active integration instance found for Zendesk")
+            return {"Status": "Failed", "Message": "No active instance found."}
+
+    @mcp.tool()
+    async def zendesk_ping(case_id: Annotated[str, Field(..., description="The ID of the case.")], alert_group_identifiers: Annotated[List[str], Field(..., description="Identifiers for the alert groups.")], target_entities: Annotated[List[TargetEntity], Field(default_factory=list, description="Optional list of specific target entities (Identifier, EntityType) to run the action on.")], scope: Annotated[str, Field(default="All entities", description="Defines the scope for the action.")]) -> dict:
+        """Test Connectivity
+
+        Returns:
+            dict: A dictionary containing the result of the action execution.
+        """
+        final_target_entities: Optional[List[TargetEntity]] = None
+        final_scope: Optional[str] = None
+        is_predefined_scope: Optional[bool] = None
+    
+        if target_entities:
+            # Specific target entities provided, ignore scope parameter
+            final_target_entities = target_entities
+            final_scope = None
+            is_predefined_scope = False
+        else:
+            # Check if the provided scope is valid
+            if scope not in bindings.valid_scopes:
+                allowed_values_str = ", ".join(sorted(list(bindings.valid_scopes)))
+                return {
+                    "Status": "Failed",
+                    "Message": f"Invalid scope '{scope}'. Allowed values are: {allowed_values_str}",
+                }
+            final_target_entities = [] # Pass empty list for entities when using scope
+            final_scope = scope
+            is_predefined_scope = True
+    
+        # Fetch integration instance identifier
+        try:
+            instance_response = await bindings.http_client.get(
+                Endpoints.LIST_INTEGRATION_INSTANCES.format(INTEGRATION_NAME="Zendesk")
+            )
+            instances = instance_response.get("integration_instances", [])
+        except Exception as e:
+            print(f"Error fetching instance for Zendesk: {e}")
+            return {"Status": "Failed", "Message": f"Error fetching instance: {e}"}
+    
+        if instances:
+            instance_identifier = instances[0].get("identifier")
+            if not instance_identifier:
+                return {"Status": "Failed", "Message": "Instance found but identifier is missing."}
+    
+            script_params = {}
+    
+            # Prepare data model for the API request
+            action_data = ApiManualActionDataModel(
+                alertGroupIdentifiers=alert_group_identifiers,
+                caseId=case_id,
+                targetEntities=final_target_entities,
+                scope=final_scope,
+                isPredefinedScope=is_predefined_scope,
+                actionProvider="Scripts",
+                actionName="Zendesk_Ping",
+                properties={
+                    "IntegrationInstance": instance_identifier,
+                    "ScriptName": "Zendesk_Ping",
+                    "ScriptParametersEntityFields": json.dumps(script_params)
+                }
+            )
+    
+            try:
+                execution_response = await bindings.http_client.post(
+                    Endpoints.EXECUTE_MANUAL_ACTION,
+                    req=action_data.model_dump()
+                )
+                return execution_response
+            except Exception as e:
+                print(f"Error executing action Zendesk_Ping for Zendesk: {e}")
+                return {"Status": "Failed", "Message": f"Error executing action: {e}"}
+        else:
+            print(f"Warning: No active integration instance found for Zendesk")
+            return {"Status": "Failed", "Message": "No active instance found."}
+
+    @mcp.tool()
+    async def zendesk_apply_macros_on_ticket(case_id: Annotated[str, Field(..., description="The ID of the case.")], alert_group_identifiers: Annotated[List[str], Field(..., description="Identifiers for the alert groups.")], ticket_id: Annotated[str, Field(..., description="Ticket number.")], macro_title: Annotated[str, Field(..., description="")], target_entities: Annotated[List[TargetEntity], Field(default_factory=list, description="Optional list of specific target entities (Identifier, EntityType) to run the action on.")], scope: Annotated[str, Field(default="All entities", description="Defines the scope for the action.")]) -> dict:
+        """
+Apply macro to a ticket
+
+Action Parameters: Ticket ID: Ticket number., Macro Title:
+
+Returns:
+dict: A dictionary containing the result of the action execution.
+"""
+        final_target_entities: Optional[List[TargetEntity]] = None
+        final_scope: Optional[str] = None
+        is_predefined_scope: Optional[bool] = None
+    
+        if target_entities:
+            # Specific target entities provided, ignore scope parameter
+            final_target_entities = target_entities
+            final_scope = None
+            is_predefined_scope = False
+        else:
+            # Check if the provided scope is valid
+            if scope not in bindings.valid_scopes:
+                allowed_values_str = ", ".join(sorted(list(bindings.valid_scopes)))
+                return {
+                    "Status": "Failed",
+                    "Message": f"Invalid scope '{scope}'. Allowed values are: {allowed_values_str}",
+                }
+            final_target_entities = [] # Pass empty list for entities when using scope
+            final_scope = scope
+            is_predefined_scope = True
+    
+        # Fetch integration instance identifier
+        try:
+            instance_response = await bindings.http_client.get(
+                Endpoints.LIST_INTEGRATION_INSTANCES.format(INTEGRATION_NAME="Zendesk")
+            )
+            instances = instance_response.get("integration_instances", [])
+        except Exception as e:
+            print(f"Error fetching instance for Zendesk: {e}")
+            return {"Status": "Failed", "Message": f"Error fetching instance: {e}"}
+    
+        if instances:
+            instance_identifier = instances[0].get("identifier")
+            if not instance_identifier:
+                return {"Status": "Failed", "Message": "Instance found but identifier is missing."}
+    
+            script_params = {}
+            script_params["Ticket ID"] = ticket_id
+            script_params["Macro Title"] = macro_title
+    
+            # Prepare data model for the API request
+            action_data = ApiManualActionDataModel(
+                alertGroupIdentifiers=alert_group_identifiers,
+                caseId=case_id,
+                targetEntities=final_target_entities,
+                scope=final_scope,
+                isPredefinedScope=is_predefined_scope,
+                actionProvider="Scripts",
+                actionName="Zendesk_Apply Macros On Ticket",
+                properties={
+                    "IntegrationInstance": instance_identifier,
+                    "ScriptName": "Zendesk_Apply Macros On Ticket",
+                    "ScriptParametersEntityFields": json.dumps(script_params)
+                }
+            )
+    
+            try:
+                execution_response = await bindings.http_client.post(
+                    Endpoints.EXECUTE_MANUAL_ACTION,
+                    req=action_data.model_dump()
+                )
+                return execution_response
+            except Exception as e:
+                print(f"Error executing action Zendesk_Apply Macros On Ticket for Zendesk: {e}")
+                return {"Status": "Failed", "Message": f"Error executing action: {e}"}
+        else:
+            print(f"Warning: No active integration instance found for Zendesk")
+            return {"Status": "Failed", "Message": "No active instance found."}
+
+    @mcp.tool()
+    async def zendesk_update_ticket(case_id: Annotated[str, Field(..., description="The ID of the case.")], alert_group_identifiers: Annotated[List[str], Field(..., description="Identifiers for the alert groups.")], ticket_id: Annotated[str, Field(..., description="Ticket number.")], subject: Annotated[str, Field(default=None, description="The subject of the ticket.")], assigned_user: Annotated[str, Field(default=None, description="User full name.")], assignment_group: Annotated[str, Field(default=None, description="Group name.")], priority: Annotated[str, Field(default=None, description="Priority will be one of the following: urgent, high, normal or low.")], ticket_type: Annotated[str, Field(default=None, description="The ticket type will be one of the following: problem, incident, question or task.")], tag: Annotated[str, Field(default=None, description="Tag to add to the ticket.")], status: Annotated[str, Field(default=None, description="The status will be one of the following: new, open, pending, hold, solved or closed.")], internal_note: Annotated[bool, Field(default=None, description="Specify whether the comment should be public, or internal. Unchecked means it will be public, checked means it will be internal only.")], additional_comment: Annotated[str, Field(default=None, description="If you want to add a comment to the ticket, specify the text you would like to add as a comment here.")], target_entities: Annotated[List[TargetEntity], Field(default_factory=list, description="Optional list of specific target entities (Identifier, EntityType) to run the action on.")], scope: Annotated[str, Field(default="All entities", description="Defines the scope for the action.")]) -> dict:
+        """Update existing ticket details
+
+        Returns:
+            dict: A dictionary containing the result of the action execution.
+        """
+        final_target_entities: Optional[List[TargetEntity]] = None
+        final_scope: Optional[str] = None
+        is_predefined_scope: Optional[bool] = None
+    
+        if target_entities:
+            # Specific target entities provided, ignore scope parameter
+            final_target_entities = target_entities
+            final_scope = None
+            is_predefined_scope = False
+        else:
+            # Check if the provided scope is valid
+            if scope not in bindings.valid_scopes:
+                allowed_values_str = ", ".join(sorted(list(bindings.valid_scopes)))
+                return {
+                    "Status": "Failed",
+                    "Message": f"Invalid scope '{scope}'. Allowed values are: {allowed_values_str}",
+                }
+            final_target_entities = [] # Pass empty list for entities when using scope
+            final_scope = scope
+            is_predefined_scope = True
+    
+        # Fetch integration instance identifier
+        try:
+            instance_response = await bindings.http_client.get(
+                Endpoints.LIST_INTEGRATION_INSTANCES.format(INTEGRATION_NAME="Zendesk")
+            )
+            instances = instance_response.get("integration_instances", [])
+        except Exception as e:
+            print(f"Error fetching instance for Zendesk: {e}")
+            return {"Status": "Failed", "Message": f"Error fetching instance: {e}"}
+    
+        if instances:
+            instance_identifier = instances[0].get("identifier")
+            if not instance_identifier:
+                return {"Status": "Failed", "Message": "Instance found but identifier is missing."}
+    
+            script_params = {}
+            script_params["Ticket ID"] = ticket_id
+            if subject is not None:
+                script_params["Subject"] = subject
+            if assigned_user is not None:
+                script_params["Assigned User"] = assigned_user
+            if assignment_group is not None:
+                script_params["Assignment Group"] = assignment_group
+            if priority is not None:
+                script_params["Priority"] = priority
+            if ticket_type is not None:
+                script_params["Ticket Type"] = ticket_type
+            if tag is not None:
+                script_params["Tag"] = tag
+            if status is not None:
+                script_params["Status"] = status
+            if internal_note is not None:
+                script_params["Internal Note"] = internal_note
+            if additional_comment is not None:
+                script_params["Additional Comment"] = additional_comment
+    
+            # Prepare data model for the API request
+            action_data = ApiManualActionDataModel(
+                alertGroupIdentifiers=alert_group_identifiers,
+                caseId=case_id,
+                targetEntities=final_target_entities,
+                scope=final_scope,
+                isPredefinedScope=is_predefined_scope,
+                actionProvider="Scripts",
+                actionName="Zendesk_Update Ticket",
+                properties={
+                    "IntegrationInstance": instance_identifier,
+                    "ScriptName": "Zendesk_Update Ticket",
+                    "ScriptParametersEntityFields": json.dumps(script_params)
+                }
+            )
+    
+            try:
+                execution_response = await bindings.http_client.post(
+                    Endpoints.EXECUTE_MANUAL_ACTION,
+                    req=action_data.model_dump()
+                )
+                return execution_response
+            except Exception as e:
+                print(f"Error executing action Zendesk_Update Ticket for Zendesk: {e}")
+                return {"Status": "Failed", "Message": f"Error executing action: {e}"}
+        else:
+            print(f"Warning: No active integration instance found for Zendesk")
+            return {"Status": "Failed", "Message": "No active instance found."}
+
+    @mcp.tool()
+    async def zendesk_search_tickets(case_id: Annotated[str, Field(..., description="The ID of the case.")], alert_group_identifiers: Annotated[List[str], Field(..., description="Identifiers for the alert groups.")], search_query: Annotated[str, Field(..., description="Query content(e.g: type:ticket status:pending).")], target_entities: Annotated[List[TargetEntity], Field(default_factory=list, description="Optional list of specific target entities (Identifier, EntityType) to run the action on.")], scope: Annotated[str, Field(default="All entities", description="Defines the scope for the action.")]) -> dict:
+        """Search tickets by keyword
+
+        Returns:
+            dict: A dictionary containing the result of the action execution.
+        """
+        final_target_entities: Optional[List[TargetEntity]] = None
+        final_scope: Optional[str] = None
+        is_predefined_scope: Optional[bool] = None
+    
+        if target_entities:
+            # Specific target entities provided, ignore scope parameter
+            final_target_entities = target_entities
+            final_scope = None
+            is_predefined_scope = False
+        else:
+            # Check if the provided scope is valid
+            if scope not in bindings.valid_scopes:
+                allowed_values_str = ", ".join(sorted(list(bindings.valid_scopes)))
+                return {
+                    "Status": "Failed",
+                    "Message": f"Invalid scope '{scope}'. Allowed values are: {allowed_values_str}",
+                }
+            final_target_entities = [] # Pass empty list for entities when using scope
+            final_scope = scope
+            is_predefined_scope = True
+    
+        # Fetch integration instance identifier
+        try:
+            instance_response = await bindings.http_client.get(
+                Endpoints.LIST_INTEGRATION_INSTANCES.format(INTEGRATION_NAME="Zendesk")
+            )
+            instances = instance_response.get("integration_instances", [])
+        except Exception as e:
+            print(f"Error fetching instance for Zendesk: {e}")
+            return {"Status": "Failed", "Message": f"Error fetching instance: {e}"}
+    
+        if instances:
+            instance_identifier = instances[0].get("identifier")
+            if not instance_identifier:
+                return {"Status": "Failed", "Message": "Instance found but identifier is missing."}
+    
+            script_params = {}
+            script_params["Search Query"] = search_query
+    
+            # Prepare data model for the API request
+            action_data = ApiManualActionDataModel(
+                alertGroupIdentifiers=alert_group_identifiers,
+                caseId=case_id,
+                targetEntities=final_target_entities,
+                scope=final_scope,
+                isPredefinedScope=is_predefined_scope,
+                actionProvider="Scripts",
+                actionName="Zendesk_Search Tickets",
+                properties={
+                    "IntegrationInstance": instance_identifier,
+                    "ScriptName": "Zendesk_Search Tickets",
+                    "ScriptParametersEntityFields": json.dumps(script_params)
+                }
+            )
+    
+            try:
+                execution_response = await bindings.http_client.post(
+                    Endpoints.EXECUTE_MANUAL_ACTION,
+                    req=action_data.model_dump()
+                )
+                return execution_response
+            except Exception as e:
+                print(f"Error executing action Zendesk_Search Tickets for Zendesk: {e}")
+                return {"Status": "Failed", "Message": f"Error executing action: {e}"}
+        else:
+            print(f"Warning: No active integration instance found for Zendesk")
+            return {"Status": "Failed", "Message": "No active instance found."}


### PR DESCRIPTION
## Summary
- copy selected marketplace clients from `google/mcp-security`
- add central registry to expose their tools
- document usage in README
- store credentials as 1Password references in `.env`

## Testing
- `python -m py_compile mcp_marketplace/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6870da3c945c832f92b0331b7eb1bea4